### PR TITLE
Fix performance issues identified by analysis

### DIFF
--- a/charon.c
+++ b/charon.c
@@ -187,7 +187,7 @@ void do_tx( uint8_t *buff, int len, int is_retrans, uint8_t *dst_mac, uint8_t is
 
  
  if(is_broadcast==0x00) {
-   is_route = is_batman_route(bat_route, dst_ofdm0_mac);
+   if(!is_retrans) is_route = is_batman_route(bat_route, dst_ofdm0_mac);
 
    fprintf(stderr, " lookup dst_mac,  %02x:%02x:%02x:%02x:%02x:%02x", 
       dst_ofdm0_mac[0],

--- a/ofdm_rx.c
+++ b/ofdm_rx.c
@@ -102,7 +102,7 @@ static int data_rate_kbps;
 void bump_nco() {
   static int nco_mod=0;
   if(nco_mod++%128==0) {
-    nco_crcf_set_frequency(ofdm_nco, (rand()/RAND_MAX)*1e-4  );  //spread some of the dc offset /flicker noise out
+    nco_crcf_set_frequency(ofdm_nco, ((float)rand()/(float)RAND_MAX)*1e-4  );  //spread some of the dc offset /flicker noise out
                                                                  // by +/- 140Hz
   }
 }
@@ -349,10 +349,6 @@ is_accept=0;
   //framesyncstats_print(&_stats);
   //ofdmflexframesync_print(fs);
 
-
-  if(total_good_frames%32==0) {
-    //fprintf(stderr, "\r\ntotal good/bad frames: %d / %d   %lld bytes, PER: %3.2f %, h_, p_: %d, %d, time: %lld, tput: %lld kbps, tput: %4.1f KBytes/sec, drate %lld kbps, rssi %3.1f dBm\n\0", total_good_frames, total_bad_frames, total_bytes, per, _header_valid, _payload_valid, time_secs, kbps, (float) kbps/8.0f, drate_bps, rssi_dbm );
-  }
 
 
 

--- a/ofdm_tx.c
+++ b/ofdm_tx.c
@@ -49,8 +49,6 @@ static unsigned char ofdm_p[OFDM_M];                 // subcarrier allocation (n
 static int ofdm_last_symbol;
 static int ofdm_index=0;
 
-static int i;
-
 static ofdmflexframegen ofdm_fg;
 
 static timer_obj *timer1;
@@ -162,9 +160,7 @@ int do_ofdm_tx( uint8_t *buffer, int len, int is_retrans, int do_dump_rx, int is
 
   //fill the rest of ofdm_payload with the buffer skipping past charon offset bytes
   //note that len==0 for ACKS, so we use tlen to tx
-    for(i=0;i<len;i++) {
-     ofdm_payload[charon_added_length+i] = buffer[i];
-    }
+    memcpy(&ofdm_payload[charon_added_length], buffer, len);
 
 do_send:
   timer_reset(timer1);

--- a/timers.c
+++ b/timers.c
@@ -59,7 +59,6 @@ timer_obj * create_timer(void) {
 /////////////////////////////////////////////////////////////
 void timer_reset(timer_obj *o) {
   gettimeofday(&o->start, NULL);
-  gettimeofday(&o->end, NULL);
 }
 
 


### PR DESCRIPTION
- ofdm_rx.c: Fix integer division bug in bump_nco(): (rand()/RAND_MAX) is
  always 0 due to int/int truncation; cast to float so NCO frequency is
  uniformly random in [0, 1e-4] as intended.

- timers.c: Remove redundant second gettimeofday() call in timer_reset().
  Only the start time needs to be captured; end is always overwritten by
  timer_elapsed_usec(). Halves syscall cost of every timer reset.

- ofdm_tx.c: Replace byte-by-byte payload copy loop with memcpy(). Remove
  now-unused static int i.

- charon.c: Skip is_batman_route() popen on retransmissions. The route
  (dst_ofdm0_mac) was already resolved on the first TX attempt; spawning
  a new process via popen("batctl o") on every retry is unnecessary.

- ofdm_rx.c: Remove dead if(total_good_frames%32==0) block whose body
  was fully commented out, eliminating a modulo check on every good frame.

https://claude.ai/code/session_01TcKCMuP1DhLq7qH9aMG9xW