### PR TITLE
Fix liquid-dsp/libiio validation issues found during review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Charon is an embedded C application that transforms Analog Devices PlutoSDR devices into autonomous OFDM transceivers with batman-adv mesh networking. It runs on the PlutoSDR's ARM processor (Xilinx Zynq-7000 Cortex-A9) and implements a 1.4 MHz OFDM-64 QPSK wireless physical layer, providing layer-2 mesh routing for TCP/IP traffic between host systems over ISM bands (915 MHz or 2.4 GHz).
+Charon is an embedded C application that transforms Analog Devices PlutoSDR devices into autonomous OFDM transceivers with batman-adv mesh networking. It runs on the PlutoSDR's ARM processor (Xilinx Zynq-7000 Cortex-A9) and implements a 1.4 MHz OFDM-128 QPSK wireless physical layer, providing layer-2 mesh routing for TCP/IP traffic between host systems over ISM bands (915 MHz or 2.4 GHz).
 
 Named after one of Pluto's moons.
 
@@ -60,7 +60,7 @@ timers.c          Microsecond-resolution timers (gettimeofday-based)
 glibc_compat.c    glibc compatibility shims — wraps __isoc23_strtol, __isoc23_strtoll,
                   __isoc23_strtoul, and __isoc23_strtoull via linker --wrap flags
 
-ofdm_conf.h       OFDM parameters (64 subcarriers, QPSK, FEC, 8x decimation)
+ofdm_conf.h       OFDM parameters (128 subcarriers, QPSK, FEC, 1x decimation)
 ofdm.h            liquid-dsp internal struct definitions
 ethernet.h        Ethernet frame structures
 

--- a/ofdm_rx.c
+++ b/ofdm_rx.c
@@ -146,8 +146,7 @@ is_accept=0;
 
   if(data_rate_kbps==0) {
     data_rate_kbps = (((sample_freq_hz / DECIMATE_INTERPOLATE_FACTOR)/(OFDM_M+CP_LEN+TAPER_LEN)) * (92*_stats.mod_bps)) /1e3; //92 assumes 128-subcarriers with 92 being data
-    data_rate_kbps *= ( (8.0/12.0) * (64.0/72.0) );   //adjust for FEC coding rate
-                                                      //HAMMING (8/12), SECDED (64/72)
+    data_rate_kbps *= (64.0/72.0);   //adjust for FEC coding rate: SECDED (64/72), inner FEC is NONE (rate 1.0)
   }
 
   lbt_backoff();  //we received something, so wait at least an ofdm symbol before transmitting

--- a/pluto.c
+++ b/pluto.c
@@ -444,13 +444,11 @@ int pluto_transmit(float complex *buffer, int len, int do_dump_rx, int is_last)
     
     if(is_last) {
 
-      //zero pad the last symbol
-      if(more_tx_data==0) {
-        while(tx_p_dat != tx_p_end) {
-          ((int16_t*)tx_p_dat)[0] = 0; 
-          ((int16_t*)tx_p_dat)[1] = 0; 
-          tx_p_dat += tx_p_inc;
-        }
+      //zero pad the remaining buffer before final push
+      while(tx_p_dat != tx_p_end) {
+        ((int16_t*)tx_p_dat)[0] = 0;
+        ((int16_t*)tx_p_dat)[1] = 0;
+        tx_p_dat += tx_p_inc;
       }
 
       more_tx_data=0;


### PR DESCRIPTION
- Fix data rate display: remove incorrect Hamming(8/12) FEC rate factor
  since inner FEC is LIQUID_FEC_NONE (rate 1.0), not Hamming
- Fix TX buffer zero-padding: always zero-pad remaining buffer on last
  symbol push, preventing stale data from being transmitted
- Fix CLAUDE.md: update OFDM-64 to OFDM-128 and 8x to 1x decimation
  to match actual ofdm_conf.h values

https://claude.ai/code/session_01KyHncQcwR8Mpt8cBHaAwVn