### PR TITLE
Remove dead code, unused variables, and duplicate definitions

### DIFF
--- a/charon.c
+++ b/charon.c
@@ -24,19 +24,16 @@
 #include "timers.h"
 
 #include <iio.h>
-#include <ctype.h>
 #include <time.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <complex.h>
-#include <math.h>
 
 #include <unistd.h>
-#include <arpa/inet.h>
 
 #include <getopt.h>
-  
+
 #include "liquid/liquid.h"
 
 #include "pluto.h"
@@ -61,14 +58,9 @@ static int do_loopback_test = 0;
 
 static int max_retrans;
 
-//opts
 static float IF;
 static float QF;
 static float complex sample;
-static int ii=0;
-
-static int first_tx=0;
-static int i;
 
 static uint8_t tap_buffer[2342];
 static int n;
@@ -82,10 +74,6 @@ static timer_obj *agc_timer_slow;
 static int got_ack;
 static long long ack_timeout;
 
-static long long cur_time;
-static long long ptime;
-
-static int ack_to_scale;
 static uint8_t is_broadcast;
 static uint8_t dst_mac[6];
 
@@ -191,14 +179,12 @@ int main (int argc, char **argv) {
   init_ofdm_rx();
   init_ofdm_tx();
 
-
   pluto_set_in_sample_freq( sample_freq_hz );
   pluto_set_in_bw( rf_bandwidth );
   pluto_set_out_bw( rf_bandwidth );
 
   pluto_set_rx_freq( freq_rxtx_hz );  //tx freq also set here
   pluto_set_out_gain( -80 );
-
 
   ack_timer = create_timer();
   timer_reset(ack_timer);
@@ -210,8 +196,6 @@ int main (int argc, char **argv) {
   timer_reset(agc_timer_fast);
   agc_timer_slow = create_timer();
   timer_reset(agc_timer_slow);
-
-
 
   main_loop();
   fprintf(stderr, "\n enter while main_loop");
@@ -260,7 +244,7 @@ void do_send_ack(uint8_t *ack_mac) {
 void do_tx( uint8_t *buff, int len, int is_retrans, uint8_t *dst_mac, uint8_t is_broadcast, uint32_t pid) {
 
 
- sprintf(bat_route, "%02x:%02x:%02x:%02x:%02x:%02x\0", 
+ sprintf(bat_route, "%02x:%02x:%02x:%02x:%02x:%02x",
     dst_mac[0],
     dst_mac[1],
     dst_mac[2],
@@ -332,7 +316,7 @@ void check_agc(void) {
 
     if( rssi > -30 && in_gain > 16) {
       pluto_bump_agc_down(-4);
-      fprintf(stderr, "\ncurrent RSSI: %d, in_gain %lld", rssi, in_gain); 
+      fprintf(stderr, "\ncurrent RSSI: %lld, in_gain %lld", rssi, in_gain);
     }
 
     timer_reset(agc_timer_fast);
@@ -344,7 +328,7 @@ void check_agc(void) {
     in_gain = pluto_get_in_gain();
 
     if( in_gain < 73) {
-      fprintf(stderr, "\ncurrent RSSI: %d, in_gain %lld", rssi, in_gain); 
+      fprintf(stderr, "\ncurrent RSSI: %lld, in_gain %lld", rssi, in_gain);
       pluto_set_in_gain(73);
       pluto_set_in_gain_auto_fast();
 

--- a/config.c
+++ b/config.c
@@ -27,17 +27,8 @@
 #include <unistd.h>
 #include <arpa/inet.h>
 
-#include "liquid/liquid.h"
-
-#include "pluto.h"
 #include "ofdm_conf.h"
-#include "ofdm_rx.h"
-#include "ofdm_tx.h"
-#include "charon.h"
-
 #include "tap_device.h"
-#include "fftw3.h"
-#include "ofdm.h"
 #include "util.h"
 #include "config.h"
 
@@ -309,7 +300,7 @@ void read_config() {
       sleep(1);
       system("/sbin/ip link set up dev mesh-bridge");
       sleep(1);
-      sprintf( cmd_str, "/sbin/ifconfig mesh-bridge %s up\0", usb_ip); 
+      sprintf(cmd_str, "/sbin/ifconfig mesh-bridge %s up", usb_ip);
       system(cmd_str);
       sleep(1);
   }
@@ -340,12 +331,12 @@ void read_config() {
       sleep(1);
       system("/sbin/ip link set up dev mesh-bridge");
       sleep(1);
-      sprintf( cmd_str, "/sbin/ifconfig mesh-bridge %s up\0", usb_ip); 
+      sprintf(cmd_str, "/sbin/ifconfig mesh-bridge %s up", usb_ip);
       system(cmd_str);
       sleep(1);
   }
 
-  sprintf( cmd_str, "/usr/sbin/batctl it %d\0", bat_ogm_interval); 
+  sprintf(cmd_str, "/usr/sbin/batctl it %d", bat_ogm_interval);
   system(cmd_str); //originator frame interval in ms 
 
   fprintf(stderr,"\ngiving charon a cpu core to itself.");

--- a/ethernet.h
+++ b/ethernet.h
@@ -105,26 +105,6 @@ typedef struct __attribute__((packed))
 }
 batman_unicast;
 
-#define TCP_FIN 0x01
-#define TCP_SYN 0x02
-#define TCP_RST 0x04
-#define TCP_PSH 0x08
-#define TCP_ACK 0x10
-#define TCP_URG 0x20
-#define TCP_CTL 0x3f
-
-#define TCP_OPT_END     0
-#define TCP_OPT_NOOP    1
-#define TCP_OPT_MSS     2
-#define TCP_OPT_WIN_SCALE 3
-#define TCP_OPT_SACK  4
-#define TCP_OPT_TIMESTAMP 8
-
-#define TCP_MAX_OPTIONS_LEN 20
-
-#define ICMP_ECHO_REPLY 0
-#define ICMP_ECHO_REQUEST 8
-
 typedef struct __attribute__((packed))
 {
   uint8_t     version;

--- a/ofdm_rx.c
+++ b/ofdm_rx.c
@@ -20,17 +20,13 @@
 //OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //SOFTWARE.
 #include "timers.h"
-//
+
 #include <iio.h>
 #include <stdlib.h>
-#include <ctype.h>
 #include <stdio.h>
 #include <time.h>
 #include <string.h>
-#include <stdlib.h>
-#include <unistd.h>
 #include <sys/time.h>
-#include <math.h>
 #include <complex.h>
 #include "liquid/liquid.h"
 
@@ -64,9 +60,6 @@ static float per;
 static long long rx_gain;
 static float rssi_dbm;
 
-#define MAX_CONSTELLATION_POINTS 1024
-static float complex frame_sym_samples[MAX_CONSTELLATION_POINTS];
-
 static struct timeval start;
 static struct timeval end;
 static long long kbit_bytes;
@@ -93,7 +86,6 @@ static uint8_t rec_ack[6];
 static int is_broadcast = 0;
 static int is_ack=0;
 static int is_accept=0;
-static int i;
 
 static int data_rate_kbps;
 
@@ -212,22 +204,15 @@ is_accept=0;
         is_accept=1;
         if( memcmp( &(ethhdr_charon->dst_mac), mac_all_one, 6) == 0 ) is_broadcast=1;
 
-       // fprintf(stderr, "\nRF_IN is charon type, bc:%d, ", is_broadcast);
 
         if( memcmp( &(ethhdr_charon->src_mac), ofdm0_mac, 6) == 0 ) {
           fprintf(stderr,"\nRF_IN-> dropped (srcmac==ofdm0_mac)");
-          //we sent this, so just drop it.
           return 0;
         }
 
-
         if( !is_broadcast && memcmp( &(ethhdr_charon->dst_mac), ofdm0_mac, 6) != 0 ) {
-          //this is not our tap mac, so drop it.
           fprintf(stderr,"\nRF_IN-> not-acking. drop (dstmac!=ofdm0_mac)");
-          //for(i=0;i<32;i++) {
-           // fprintf(stderr, "%02x,", _payload[i] );
-          //}
-          if(tcp_share_backoff<max_tcp_share_backoff) tcp_share_backoff += symbol_delay_timeout; 
+          if(tcp_share_backoff<max_tcp_share_backoff) tcp_share_backoff += symbol_delay_timeout;
           return 0;
         }
 
@@ -235,10 +220,6 @@ is_accept=0;
 
       }
       else {
-        //fprintf(stderr, "\nRF_IN not charon, len=%d , type: %04x, first 32->  ", _payload_len, htons(ethhdr_charon->eth_type));
-        //for(i=0;i<32;i++) {
-         // fprintf(stderr, "%02x,", _payload[i] );
-        //}
         return 0;
       }
     }
@@ -351,15 +332,6 @@ is_accept=0;
       drate = 0;
     }
 
-
-    //only send constellation if it was a validated frame
-    //memset(frame_sym_samples,0x00,sizeof(frame_sym_samples));
-    //int i;
-    //for(i=0;i<MAX_CONSTELLATION_POINTS;i++) {
-      //frame_sym_samples[i] = _stats.framesyms[i];
-      //fprintf(stderr, "\n%f,%f", creal(frame_sym_samples[i]), cimag(frame_sym_samples[i]) );
-    //}
-
   }
   else {
     nco_crcf_set_frequency(_qq->nco_rx, last_good_nco_freq);
@@ -374,22 +346,7 @@ is_accept=0;
 
   if(total_good_frames>0) per = (float) ( (float) total_bad_frames / (float) (total_good_frames+total_bad_frames)) * 100.0f;
 
-  //framesyncstats_print(&_stats);
-  //ofdmflexframesync_print(fs);
-
-
-
-
-
-    //fprintf(stderr,"    EVM                 :   %12.8f dB\n", _stats->evm);
-    //fprintf(stderr,"    rssi                :   %12.8f dB\n", _stats->rssi);
-    //fprintf(stderr,"    carrier offset      :   %12.8f Fs\n", _stats->cfo);
-    //fprintf(stderr,"    num symbols         :   %u\n", _stats->num_framesyms);
-    //fprintf(stderr,"    validity check      :   %s\n", crc_scheme_str[_stats->check][0]);
-    //fprintf(stderr,"    fec (inner)         :   %s\n", fec_scheme_str[_stats->fec0][0]);
-    //fprintf(stderr,"    fec (outer)         :   %s\n", fec_scheme_str[_stats->fec1][0]);
-
-  return 0; 
+  return 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ofdm_tx.c
+++ b/ofdm_tx.c
@@ -48,7 +48,6 @@ static unsigned char ofdm_header[8];            // header data
 static unsigned char ofdm_payload[32*1024]; 
 static unsigned char ofdm_p[OFDM_M];                 // subcarrier allocation (null/pilot/data)
 static int ofdm_last_symbol;
-static int ofdm_index=0;
 
 static ofdmflexframegen ofdm_fg;
 

--- a/pluto.c
+++ b/pluto.c
@@ -21,16 +21,13 @@
 //SOFTWARE.
 
 #include <iio.h>
-#include <ctype.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <complex.h>
 #include <unistd.h>
-#include <getopt.h>
 #include <math.h>
-#include <float.h>
-  
+
 #include "liquid/liquid.h"
 #include "filters/pluto/pluto_filters.h"
 #include "ad9361.h"
@@ -66,11 +63,9 @@ static struct iio_channel *phy_altvoltage0;   // phy "altvoltage0" output (RX LO
 static struct iio_channel *phy_altvoltage1;   // phy "altvoltage1" output (TX LO)
 
 static struct iio_buffer *rxbuf;
-static void *p_dat, *p_end, *p_start;
+static void *p_dat, *p_end;
 static ptrdiff_t p_inc;
 static int pluto_rx_initialized=0;
-
-static int tx_fd;
 
 static struct iio_buffer *txbuf;
 static char *tx_p_dat, *tx_p_end;
@@ -79,27 +74,15 @@ static int pluto_tx_initialized=0;
 
 static int tx_enabled=0;
 
-static int nbytes_tx;
 static int llen;
 static int ii=0;
 static int n_rx;
 
 static long long prev_gain;
 
-static int64_t time_to_tx;
-
-static long long agc_gain = 72;
-static int agc_locked=0;
-
 int rx_timeout;
-static int16_t _txi;
-static int16_t _txq;
-static int16_t _rxi;
-static int16_t _rxq;
-static int pushed;
 static struct iio_context *ctx;
 static long long rssi;
-static long long gain_val;
 static int more_data;
 static int more_tx_data;
 
@@ -134,11 +117,7 @@ struct iio_context * pluto_init_txrx() {
     iio_channel_enable(tx0_i);
     iio_channel_enable(tx0_q);
 
-    ad9361_set_bb_rate_custom_filter_auto	(phy, sample_freq_hz);
-
-    //pluto_enable_fir(0);
-    //pluto_set_filter();
-    //pluto_enable_fir(1);
+    ad9361_set_bb_rate_custom_filter_auto(phy, sample_freq_hz);
 
     pluto_set_out_gain( -80 );
 
@@ -166,16 +145,13 @@ struct iio_context * pluto_init_txrx() {
       pluto_rx_initialized=1;
       iio_buffer_set_blocking_mode(rxbuf,false);
 
-      p_inc = iio_buffer_step(rxbuf);//no need to init this every loop
-
-      //fprintf(stderr, "\npluto rx buffer size: %d", IIO_RX_BUFFER_SIZE ); 
+      p_inc = iio_buffer_step(rxbuf);
      }
 
     //TX Buffer
     if(!pluto_tx_initialized) {
 
-      txbuf = iio_device_create_buffer(tx_dev, (OFDM_M+CP_LEN+TAPER_LEN), false); //0==auto
-      //fprintf(stderr, "\npluto tx buffer size: %d , buffer: %d", ofdm_get_sample_count(PAYLOAD_LEN) , (OFDM_M+CP_LEN+TAPER_LEN)*DECIMATE_INTERPOLATE_FACTOR/4 ); 
+      txbuf = iio_device_create_buffer(tx_dev, (OFDM_M+CP_LEN+TAPER_LEN), false);
 
       if (!txbuf) {
           perror("Could not create TX buffer");
@@ -218,8 +194,6 @@ long long pluto_get_in_gain(void) {
       "hardwaregain",
       &gain_val);
 
-  //fprintf(stderr, "\ngain: %lld", gain_val);
-
   return gain_val;
 }
 ///////////////////////////////////////////////////////////////////////////////////////
@@ -243,8 +217,6 @@ long long pluto_get_in_rssi(void) {
         phy_voltage0_in,
       "rssi",
       &rssi);
-
-  //fprintf(stderr, "\nin_rssi: %lld", -rssi);
 
   return -rssi;
 }
@@ -330,7 +302,7 @@ void pluto_set_in_sample_freq(long long sfreq) {
         "sampling_frequency",
         sfreq);
 
-    ad9361_set_bb_rate_custom_filter_auto	(phy, sfreq);
+    ad9361_set_bb_rate_custom_filter_auto(phy, sfreq);
 
     current_sample_freq = sfreq;
 }
@@ -343,8 +315,6 @@ void pluto_set_out_gain(long long gain) {
       phy_voltage0_out,
       "hardwaregain",
       gain);
-  //fprintf(stderr, "\nsetting tx gain %lld", gain);
-
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////

--- a/pluto_host.c
+++ b/pluto_host.c
@@ -63,9 +63,6 @@ static int tx_enabled=0;
 static int llen;
 static int ii=0;
 
-static long long agc_gain = 72;
-static int agc_locked=0;
-
 int rx_timeout;
 
 long long pluto_current_gain;
@@ -73,7 +70,6 @@ long long current_rx_freq;
 long long current_sample_freq;
 
 static int16_t rx_buffer[16384];  // Larger buffer for UDP packets
-static int rx_buf_fill = 0;
 static int ofdm_initialized = 0;
 
 ///////////////////////////////////////////////////////////////////////////////////////

--- a/tap_device.c
+++ b/tap_device.c
@@ -27,14 +27,11 @@
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <fcntl.h>
 #include <sys/ioctl.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include <strings.h>
-#include <complex.h>
 #include <stdint.h>
 #include "tuntap.h"
 #include "private.h"
@@ -47,8 +44,6 @@
 
 static struct device *dev;
 static int debug_tap=1;
-
-static FILE *tap_f;
 
 const uint8_t mac_all_zero[6]={0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
 const uint8_t mac_all_one[6]={0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
@@ -85,7 +80,7 @@ int init_tap_device(void) {
 
   srandom(usb_ip32);  //always the same mac for a given IP. keeps the mesh from getting behind too much when a 
                       //client comes back up after re-start.
-  sprintf(tap_mac_a, "%02x:%02x:%02x:%02x:%02x:%02x\0", 
+  sprintf(tap_mac_a, "%02x:%02x:%02x:%02x:%02x:%02x",
       (uint8_t) ((random()%255)&0xfc),
       (uint8_t) (random()%255),
       (uint8_t) (random()%255),
@@ -125,7 +120,6 @@ int init_tap_device(void) {
 
   setNonblocking(dev->tun_fd);
 
-  tap_f = (FILE *) fdopen((int) dev->tun_fd, "r+");
   return 0;
 
 clean:
@@ -155,21 +149,15 @@ int setNonblocking(int fd)
 /////////////////////////////////////////////////////////////////////////////////////
 int read_tap_dev(char *buffer, int max_len, char *dst_mac, char *is_broadcast) {
 
- int i;
  int nbytes;
  int new_len;
 
  eth_frame *ethframe = (eth_frame *) buffer;
 
   batman_frame_unicast *batucast = (batman_frame_unicast *) buffer;
-  batman_frame_special *batspecial = (batman_frame_special *) buffer;
   batman_unicast *bathdr_u = &(batucast->bathdr_unicast);
 
  eth_hdr *ethhdr = (eth_hdr *) &(ethframe->ethhdr);
- ip_hdr *ip = (ip_hdr *) &(ethframe->iphdr);
- tcp_hdr *tcp = (tcp_hdr *) &(ethframe->ip_proto_payload);
- udp_hdr *udp = (udp_hdr *) &(ethframe->ip_proto_payload);
- uint8_t *payload = (uint8_t *) tcp->payload;
 
  nbytes = read(dev->tun_fd, buffer, max_len);
 
@@ -235,10 +223,6 @@ int read_tap_dev(char *buffer, int max_len, char *dst_mac, char *is_broadcast) {
 
   if(nbytes>0 && debug_tap) {
    fprintf(stderr,"\n\nRead %d bytes from ofdm0\n", nbytes);
- //  for(i=0;i<nbytes;i++) {
- //    if(i%32==0) fprintf(stderr,"\n");
- //    fprintf(stderr,"%02x,", buffer[i]);
- //  }
   }
  return nbytes;
 }
@@ -246,20 +230,14 @@ int read_tap_dev(char *buffer, int max_len, char *dst_mac, char *is_broadcast) {
 /////////////////////////////////////////////////////////////////////////////////////
 int write_tap_dev(char *buffer, int len) {
  int i;
- int nbytes;
  int new_len;
 
  eth_frame *ethframe = (eth_frame *) buffer;
 
-batman_frame_unicast *batucast = (batman_frame_unicast *) buffer; 
-batman_frame_special *batspecial = (batman_frame_special *) buffer; 
-  batman_unicast *bathdr_u = &(batucast->bathdr_unicast);
+ batman_frame_unicast *batucast = (batman_frame_unicast *) buffer;
+ batman_unicast *bathdr_u = &(batucast->bathdr_unicast);
 
  eth_hdr *ethhdr = (eth_hdr *) &(ethframe->ethhdr);
- ip_hdr *ip = (ip_hdr *) &(ethframe->iphdr);
- tcp_hdr *tcp = (tcp_hdr *) &(ethframe->ip_proto_payload);
- udp_hdr *udp = (udp_hdr *) &(ethframe->ip_proto_payload);
- uint8_t *payload = (uint8_t *) tcp->payload;
 
 
  if(len<=0) return 0;
@@ -294,10 +272,6 @@ batman_frame_special *batspecial = (batman_frame_special *) buffer;
 
  if(len>0 && debug_tap) {
    fprintf(stderr,"\n\nRF_IN -> writing %d bytes to ofdm0\n", len);
- //  for(i=0;i<len;i++) {
- //    if(i%32==0) fprintf(stderr,"\n");
- //    fprintf(stderr,"%02x,", buffer[i]);
- //  }
   }
 
   i = write(dev->tun_fd, buffer, len);

--- a/tcp_subs.c
+++ b/tcp_subs.c
@@ -64,8 +64,6 @@ static uint16_t upper_layer_chksum(uint8_t proto, uint8_t *eth_buffer)
 
   eth_frame *ethframe = (eth_frame *) eth_buffer;
   ip_hdr *ip = (ip_hdr *) &(ethframe->iphdr);
-  tcp_hdr *tcp = (tcp_hdr *) &(ethframe->ip_proto_payload);
-  udp_hdr *udp = (udp_hdr *) &(ethframe->ip_proto_payload);
 
   upper_layer_len = htons( ip->len ) - sizeof(ip_hdr);
 
@@ -120,10 +118,7 @@ static void sub_mss(int16_t mss_sub_size, uint8_t *eth_frame_buffer)
 {
 
   eth_frame *ethframe = (eth_frame *) eth_frame_buffer;
-  eth_hdr *ethhdr = (eth_hdr *) &(ethframe->ethhdr);
-  ip_hdr *ip = (ip_hdr *) &(ethframe->iphdr);
   tcp_hdr *tcp = (tcp_hdr *) &(ethframe->ip_proto_payload);
-  udp_hdr *udp = (udp_hdr *) &(ethframe->ip_proto_payload);
   int16_t opt_len=0;
   uint8_t *opt_ptr = (uint8_t *) tcp->payload;
   int opt_index=0;
@@ -185,19 +180,14 @@ static void sub_mss(int16_t mss_sub_size, uint8_t *eth_frame_buffer)
 ////////////////////////////////////////////////////////////////////////////////////////////
 int do_tcp_subs(uint8_t *eth_frame_buffer) {
 
-  int16_t i=0;
   int8_t recalc_chksum=0;
-
 
   eth_frame *ethframe = (eth_frame *) eth_frame_buffer;
   eth_hdr *ethhdr = (eth_hdr *) &(ethframe->ethhdr);
   ip_hdr *ip = (ip_hdr *) &(ethframe->iphdr);
   tcp_hdr *tcp = (tcp_hdr *) &(ethframe->ip_proto_payload);
-  udp_hdr *udp = (udp_hdr *) &(ethframe->ip_proto_payload);
-  uint8_t *payload = (uint8_t *) tcp->payload;
 
   if( htons( ethhdr->eth_type ) != ETH_IP_TYPE ) {
-    //fprintf(stderr, "\nnot ip4, exiting tcp_subs");
     return 0;
   }
 
@@ -220,8 +210,6 @@ int do_tcp_subs(uint8_t *eth_frame_buffer) {
     ip->chksum = 0;
     ip->chksum = ~ipchksum( (void *) ip );
 
-    //new frame length
-    //fprintf(stderr, "\ndid ip4 tcp_sub");
     return htons(ip->len) + sizeof(eth_hdr);
   }
 

--- a/timers.c
+++ b/timers.c
@@ -20,33 +20,11 @@
 //OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //SOFTWARE.
 
-#include <iio.h>
 #include <stdlib.h>
-#include <stdio.h>
 #include <time.h>
-#include <string.h>
-#include <unistd.h>
-#include <sys/time.h>
-#include <math.h>
-#include <complex.h>
-#include "liquid/liquid.h"
 
-#include "pluto.h"
-#include "ofdm_conf.h"
-#include "ofdm_rx.h"
-#include "charon.h"
-#include "fftw3.h"
-#include "ofdm.h"
-#include "tap_device.h"
 #include "timers.h"
 
-
-/////////////////////////////////////////////////////////////
-/////////////////////////////////////////////////////////////
-//typedef struct timer_obj {
-//  struct timeval start;
-//  struct timeval end;
-//} timer_obj;
 
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////


### PR DESCRIPTION
- Remove duplicate macro definitions in ethernet.h (TCP_*, ICMP_*)
- Remove duplicate #includes (stdlib.h in ofdm_rx.c, fcntl.h in tap_device.c)
- Remove unused static variables across files (charon.c: first_tx, ii, i,
  cur_time, ptime, ack_to_scale; pluto.c: tx_fd, time_to_tx, agc_locked,
  _txi/_txq/_rxi/_rxq, pushed, nbytes_tx, agc_gain, p_start, gain_val;
  pluto_host.c: agc_gain, agc_locked, rx_buf_fill; ofdm_rx.c: i,
  frame_sym_samples; ofdm_tx.c: ofdm_index)
- Remove unused local variables in tap_device.c and tcp_subs.c
- Remove commented-out debug code blocks in ofdm_rx.c, pluto.c, tap_device.c,
  tcp_subs.c, and timers.c
- Fix format string mismatches in charon.c (long long printed with %d)
- Remove redundant \0 in sprintf format strings across files
- Remove unnecessary #includes (timers.c, config.c, charon.c, ofdm_rx.c,
  pluto.c, tap_device.c)
- Remove unused tap_f FILE* and fdopen call in tap_device.c
- Fix stray tab characters in pluto.c ad9361_set_bb_rate_custom_filter_auto calls
- Clean up excessive blank lines

https://claude.ai/code/session_01HzuxpigzbapvuqXsayaQVZ