### PR TITLE
Add --save-tx and --load-rx for recording/replaying IQ samples

### DIFF
--- a/charon.c
+++ b/charon.c
@@ -56,6 +56,8 @@
 
 static int do_loopback_test = 0;
 static int tx_active = 0;
+static char *save_tx_path = NULL;
+static char *load_rx_path = NULL;
 
 static int max_retrans;
 
@@ -155,13 +157,21 @@ int main (int argc, char **argv) {
   int opt;
   static struct option long_options[] = {
     {"loopback-test", no_argument, 0, 'T'},
+    {"save-tx", required_argument, 0, 's'},
+    {"load-rx", required_argument, 0, 'l'},
     {0, 0, 0, 0}
   };
 
-  while ((opt = getopt_long(argc, argv, "T", long_options, NULL)) != -1) {
+  while ((opt = getopt_long(argc, argv, "Ts:l:", long_options, NULL)) != -1) {
     switch (opt) {
       case 'T':
         do_loopback_test = 1;
+        break;
+      case 's':
+        save_tx_path = optarg;
+        break;
+      case 'l':
+        load_rx_path = optarg;
         break;
     }
   }
@@ -176,6 +186,9 @@ int main (int argc, char **argv) {
 
   pluto_init_txrx();
   pluto_set_enable_tx( 1 );
+
+  if(save_tx_path) pluto_tx_save_open(save_tx_path);
+  if(load_rx_path) pluto_rx_load_open(load_rx_path);
 
   init_ofdm_rx();
   init_ofdm_tx();

--- a/pluto.c
+++ b/pluto.c
@@ -92,6 +92,9 @@ long long pluto_current_gain;
 long long current_rx_freq;
 long long current_sample_freq;
 
+static FILE *tx_save_fp = NULL;
+static FILE *rx_load_fp = NULL;
+
 ///////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////
 struct iio_context * pluto_init_txrx() {
@@ -443,6 +446,50 @@ void pluto_set_rx_freq(long long freq_rx_hz) {
 
 ///////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////
+void pluto_tx_save_open(const char *path) {
+  if(tx_save_fp) fclose(tx_save_fp);
+  tx_save_fp = fopen(path, "wb");
+  if(!tx_save_fp) {
+    fprintf(stderr, "\n[pluto] ERROR: could not open TX save file: %s", path);
+  } else {
+    fprintf(stderr, "\n[pluto] saving TX samples to: %s", path);
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////
+void pluto_tx_save_close(void) {
+  if(tx_save_fp) {
+    fclose(tx_save_fp);
+    tx_save_fp = NULL;
+    fprintf(stderr, "\n[pluto] TX save file closed");
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////
+void pluto_rx_load_open(const char *path) {
+  if(rx_load_fp) fclose(rx_load_fp);
+  rx_load_fp = fopen(path, "rb");
+  if(!rx_load_fp) {
+    fprintf(stderr, "\n[pluto] ERROR: could not open RX load file: %s", path);
+  } else {
+    fprintf(stderr, "\n[pluto] loading RX samples from: %s", path);
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////
+void pluto_rx_load_close(void) {
+  if(rx_load_fp) {
+    fclose(rx_load_fp);
+    rx_load_fp = NULL;
+    fprintf(stderr, "\n[pluto] RX load file closed");
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////
 int pluto_transmit(float complex *buffer, int len, int do_dump_rx, int is_last)
 {
 
@@ -460,6 +507,10 @@ int pluto_transmit(float complex *buffer, int len, int do_dump_rx, int is_last)
 
       ((int16_t*)tx_p_dat)[0] = ((const int16_t) (creal( buffer[ii] )*8192.0));  //scale to work well for OFDM waveforms
       ((int16_t*)tx_p_dat)[1] = ((const int16_t) (cimag( buffer[ii] )*8192.0));
+
+      if(tx_save_fp) {
+        fwrite(tx_p_dat, sizeof(int16_t), 2, tx_save_fp);
+      }
 
       tx_p_dat += tx_p_inc;
 
@@ -483,9 +534,11 @@ int pluto_transmit(float complex *buffer, int len, int do_dump_rx, int is_last)
         tx_p_dat += tx_p_inc;
       }
 
-      more_tx_data=0;      
+      more_tx_data=0;
       iio_buffer_push(txbuf); //send out the last symbol to the dma
       fprintf(stderr, "\n[pluto] TX: pushing final buffer and flushing RX");
+
+      if(tx_save_fp) fflush(tx_save_fp);
 
       while( iio_buffer_refill(rxbuf) > 0); //flush the rx buffer
     }
@@ -499,6 +552,18 @@ int pluto_receive() {
 
   static long long rx_sample_count = 0;
   static struct timeval rx_stat_tv = {0, 0};
+
+  if(rx_load_fp) {
+    int16_t file_buf[1400 * 2];
+    size_t samples_read = fread(file_buf, sizeof(int16_t) * 2, 1400, rx_load_fp);
+    if(samples_read == 0) {
+      fprintf(stderr, "\n[pluto] RX load file: EOF reached");
+      pluto_rx_load_close();
+      return 0;
+    }
+    do_process_iq16_batch(file_buf, (int)samples_read);
+    return 0;
+  }
 
   if(p_dat == p_end || !more_data) {
     ssize_t nbytes = iio_buffer_refill(rxbuf);

--- a/pluto.h
+++ b/pluto.h
@@ -1,4 +1,8 @@
 /* This file was automatically generated.  Do not edit! */
+void pluto_rx_load_close(void);
+void pluto_rx_load_open(const char *path);
+void pluto_tx_save_close(void);
+void pluto_tx_save_open(const char *path);
 int pluto_receive();
 int pluto_transmit(float complex *buffer,int len,int do_dump_rx,int is_last);
 void pluto_set_rx_freq(long long freq_rx_hz);

--- a/pluto_host.c
+++ b/pluto_host.c
@@ -72,6 +72,9 @@ long long current_sample_freq;
 static int16_t rx_buffer[16384];  // Larger buffer for UDP packets
 static int ofdm_initialized = 0;
 
+static FILE *tx_save_fp = NULL;
+static FILE *rx_load_fp = NULL;
+
 ///////////////////////////////////////////////////////////////////////////////////////
 // Socket helper functions
 ///////////////////////////////////////////////////////////////////////////////////////
@@ -293,6 +296,50 @@ void pluto_set_rx_freq(long long freq_rx_hz) {
 
 ///////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////
+void pluto_tx_save_open(const char *path) {
+  if(tx_save_fp) fclose(tx_save_fp);
+  tx_save_fp = fopen(path, "wb");
+  if(!tx_save_fp) {
+    fprintf(stderr, "\n[pluto] ERROR: could not open TX save file: %s", path);
+  } else {
+    fprintf(stderr, "\n[pluto] saving TX samples to: %s", path);
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////
+void pluto_tx_save_close(void) {
+  if(tx_save_fp) {
+    fclose(tx_save_fp);
+    tx_save_fp = NULL;
+    fprintf(stderr, "\n[pluto] TX save file closed");
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////
+void pluto_rx_load_open(const char *path) {
+  if(rx_load_fp) fclose(rx_load_fp);
+  rx_load_fp = fopen(path, "rb");
+  if(!rx_load_fp) {
+    fprintf(stderr, "\n[pluto] ERROR: could not open RX load file: %s", path);
+  } else {
+    fprintf(stderr, "\n[pluto] loading RX samples from: %s", path);
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////
+void pluto_rx_load_close(void) {
+  if(rx_load_fp) {
+    fclose(rx_load_fp);
+    rx_load_fp = NULL;
+    fprintf(stderr, "\n[pluto] RX load file closed");
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////
 int pluto_transmit(float complex *buffer, int len, int do_dump_rx, int is_last)
 {
     if (tx_sock_fd < 0) {
@@ -323,20 +370,37 @@ int pluto_transmit(float complex *buffer, int len, int do_dump_rx, int is_last)
         }
     }
 
+    if(tx_save_fp) {
+        fwrite(tx_buffer, sizeof(int16_t), buf_idx, tx_save_fp);
+        fflush(tx_save_fp);
+    }
+
     return 0;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////
 int pluto_receive() {
+    if(rx_load_fp) {
+        int16_t file_buf[1400 * 2];
+        size_t samples_read = fread(file_buf, sizeof(int16_t) * 2, 1400, rx_load_fp);
+        if(samples_read == 0) {
+            fprintf(stderr, "\n[pluto] RX load file: EOF reached");
+            pluto_rx_load_close();
+            return 0;
+        }
+        do_process_iq16_batch(file_buf, (int)samples_read);
+        return 0;
+    }
+
     if (rx_sock_fd < 0) {
         return 0; // Socket not initialized
     }
-    
+
     if (!ofdm_initialized) {
         return 0; // OFDM not ready yet
     }
-    
+
     // Read samples from UDP socket
     ssize_t bytes_read = recvfrom(rx_sock_fd, rx_buffer, sizeof(rx_buffer),
                                   MSG_DONTWAIT, (struct sockaddr *)&rx_src_addr, &rx_addr_len);


### PR DESCRIPTION
Adds the ability to save TX samples to a raw int16 I/Q file and to
load RX samples from a previously saved file, using pluto_transmit
and pluto_receive as the modification points. Works in both hardware
(pluto.c) and host-mode (pluto_host.c) builds.

Usage:
  charon --save-tx tx_samples.iq    # record transmitted samples
  charon --load-rx rx_samples.iq    # replay samples into RX path

File format: raw binary interleaved int16_t I/Q pairs (4 bytes/sample),
compatible with GNU Radio, SDR++, and other SDR tools.

https://claude.ai/code/session_017kom7aJxMmpLV7K1CoYLb8