### PR TITLE
Add XO correction support based on PSS sync offset

### DIFF
--- a/ofdm_rx.c
+++ b/ofdm_rx.c
@@ -380,11 +380,16 @@ void do_ofdm_rx(float complex sample) {
   // While the frame-synchronizer is hunting for the PLCP preamble, run the
   // PSS correlator in parallel.  If a PSS preamble is detected the estimated
   // CFO is applied to the inner NCO so that the subsequent PLCP sync has a
-  // better frequency starting point.
+  // better frequency starting point.  When the CFO is nonzero, also adjust
+  // the AD9361 xo_correction (40 MHz base clock) so the hardware LO and
+  // sample rates converge toward the correct values.
   if (_qq->state == OFDMFRAMESYNC_STATE_SEEKPLCP) {
     if (pss_sync_execute(sample)) {
       float cfo = pss_sync_get_freq_offset();   // cycles/sample
       nco_crcf_set_frequency(_qq->nco_rx, 2.0f * (float)M_PI * cfo);
+      if (cfo != 0.0f) {
+        pluto_apply_pss_xo_correction(cfo);
+      }
       fprintf(stderr, "\nPSS: detected CFO=%.6f rad/samp (hyp %+d sc, peak=%.3f)",
               2.0f * (float)M_PI * cfo,
               (int)(cfo * (float)OFDM_M + (cfo >= 0.0f ? 0.5f : -0.5f)),

--- a/ofdm_rx.c
+++ b/ofdm_rx.c
@@ -389,6 +389,9 @@ void do_ofdm_rx(float complex sample) {
       nco_crcf_set_frequency(_qq->nco_rx, 2.0f * (float)M_PI * cfo);
       if (cfo != 0.0f) {
         pluto_apply_pss_xo_correction(cfo);
+        // XO correction has absorbed the CFO into the hardware clock —
+        // reset the internal NCO so it doesn't double-correct.
+        nco_crcf_set_frequency(_qq->nco_rx, 0.0f);
       }
       fprintf(stderr, "\nPSS: detected CFO=%.6f rad/samp (hyp %+d sc, peak=%.3f)",
               2.0f * (float)M_PI * cfo,

--- a/pluto.c
+++ b/pluto.c
@@ -41,6 +41,8 @@
 #include "timers.h"
 #include "config.h"
 
+#define XO_BASE_HZ 40000000LL
+
 struct iio_buffer {
     const struct iio_device *dev;
     void *buffer, *userdata;
@@ -91,6 +93,8 @@ static int more_tx_data;
 long long pluto_current_gain;
 long long current_rx_freq;
 long long current_sample_freq;
+
+static long long current_xo_correction = XO_BASE_HZ;
 
 static FILE *tx_save_fp = NULL;
 static FILE *rx_load_fp = NULL;
@@ -153,6 +157,8 @@ struct iio_context * pluto_init_txrx() {
       fprintf(stderr, "\n[pluto] HW RX bandwidth: %lld Hz, TX bandwidth: %lld Hz", hw_rx_bw, hw_tx_bw);
       fprintf(stderr, "\n[pluto] HW RX LO: %lld Hz, TX LO: %lld Hz", hw_rx_lo, hw_tx_lo);
     }
+
+    pluto_init_xo_correction();
 
     fprintf(stderr, "\n[pluto] setting initial TX gain to -80 dB");
     pluto_set_out_gain( -80 );
@@ -442,6 +448,44 @@ void pluto_set_rx_freq(long long freq_rx_hz) {
     pluto_set_out_gain( -80 );
   }
 
+}
+
+///////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////
+void pluto_init_xo_correction(void) {
+  if (iio_device_attr_read_longlong(phy, "xo_correction", &current_xo_correction) == 0) {
+    fprintf(stderr, "\n[pluto] initial xo_correction: %lld Hz", current_xo_correction);
+  } else {
+    current_xo_correction = XO_BASE_HZ;
+    fprintf(stderr, "\n[pluto] could not read xo_correction, using default %lld Hz", current_xo_correction);
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////
+long long pluto_get_xo_correction(void) {
+  return current_xo_correction;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////
+void pluto_set_xo_correction(long long xo_hz) {
+  current_xo_correction = xo_hz;
+  iio_device_attr_write_longlong(phy, "xo_correction", xo_hz);
+  fprintf(stderr, "\n[pluto] set xo_correction: %lld Hz", xo_hz);
+}
+
+///////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////
+void pluto_apply_pss_xo_correction(float cfo_cycles_per_sample) {
+  double cfo_hz = (double)cfo_cycles_per_sample * (double)sample_freq_hz;
+  double xo_delta = cfo_hz * ((double)XO_BASE_HZ / (double)freq_rxtx_hz);
+  long long new_xo = current_xo_correction - (long long)round(xo_delta);
+
+  fprintf(stderr, "\n[pluto] PSS XO correction: CFO=%.1f Hz, xo_delta=%.1f Hz, new_xo=%lld Hz (was %lld)",
+          cfo_hz, xo_delta, new_xo, current_xo_correction);
+
+  pluto_set_xo_correction(new_xo);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////

--- a/pluto.h
+++ b/pluto.h
@@ -1,4 +1,8 @@
 /* This file was automatically generated.  Do not edit! */
+void pluto_apply_pss_xo_correction(float cfo_cycles_per_sample);
+void pluto_set_xo_correction(long long xo_hz);
+long long pluto_get_xo_correction(void);
+void pluto_init_xo_correction(void);
 void pluto_rx_load_close(void);
 void pluto_rx_load_open(const char *path);
 void pluto_tx_save_close(void);

--- a/pluto_host.c
+++ b/pluto_host.c
@@ -43,6 +43,7 @@
 #include "timers.h"
 #include "config.h"
 
+#define XO_BASE_HZ 40000000LL
 #define DEFAULT_PLUTO_URI "ip:192.168.2.1"
 
 struct iio_buffer {
@@ -97,6 +98,8 @@ static int more_tx_data;
 long long pluto_current_gain;
 long long current_rx_freq;
 long long current_sample_freq;
+
+static long long current_xo_correction = XO_BASE_HZ;
 
 static FILE *tx_save_fp = NULL;
 static FILE *rx_load_fp = NULL;
@@ -173,6 +176,8 @@ struct iio_context * pluto_init_txrx() {
       fprintf(stderr, "\n[pluto-host] HW RX bandwidth: %lld Hz, TX bandwidth: %lld Hz", hw_rx_bw, hw_tx_bw);
       fprintf(stderr, "\n[pluto-host] HW RX LO: %lld Hz, TX LO: %lld Hz", hw_rx_lo, hw_tx_lo);
     }
+
+    pluto_init_xo_correction();
 
     fprintf(stderr, "\n[pluto-host] setting initial TX gain to -80 dB");
     pluto_set_out_gain( -80 );
@@ -462,6 +467,44 @@ void pluto_set_rx_freq(long long freq_rx_hz) {
     pluto_set_out_gain( -80 );
   }
 
+}
+
+///////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////
+void pluto_init_xo_correction(void) {
+  if (iio_device_attr_read_longlong(phy, "xo_correction", &current_xo_correction) == 0) {
+    fprintf(stderr, "\n[pluto-host] initial xo_correction: %lld Hz", current_xo_correction);
+  } else {
+    current_xo_correction = XO_BASE_HZ;
+    fprintf(stderr, "\n[pluto-host] could not read xo_correction, using default %lld Hz", current_xo_correction);
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////
+long long pluto_get_xo_correction(void) {
+  return current_xo_correction;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////
+void pluto_set_xo_correction(long long xo_hz) {
+  current_xo_correction = xo_hz;
+  iio_device_attr_write_longlong(phy, "xo_correction", xo_hz);
+  fprintf(stderr, "\n[pluto-host] set xo_correction: %lld Hz", xo_hz);
+}
+
+///////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////
+void pluto_apply_pss_xo_correction(float cfo_cycles_per_sample) {
+  double cfo_hz = (double)cfo_cycles_per_sample * (double)sample_freq_hz;
+  double xo_delta = cfo_hz * ((double)XO_BASE_HZ / (double)freq_rxtx_hz);
+  long long new_xo = current_xo_correction - (long long)round(xo_delta);
+
+  fprintf(stderr, "\n[pluto-host] PSS XO correction: CFO=%.1f Hz, xo_delta=%.1f Hz, new_xo=%lld Hz (was %lld)",
+          cfo_hz, xo_delta, new_xo, current_xo_correction);
+
+  pluto_set_xo_correction(new_xo);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
When the PSS correlator detects a nonzero carrier frequency offset,
convert it to an XO clock error using the 40 MHz base reference and
write the corrected value to the AD9361 xo_correction attribute.  This
adjusts the hardware PLL at the source so both LO frequency and sample
rate converge toward their true values.

The correction formula: xo_delta = CFO_hz * (40 MHz / operating_freq),
applied as new_xo = current_xo - xo_delta.

At init the current xo_correction is read from the IIO device so
factory calibration is preserved as the starting point.

https://claude.ai/code/session_011SNtcV7itiTyU29LKreWyJ