### PR TITLE
Replace PSS with single CW tone for CFO estimation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Charon is an embedded C application that transforms Analog Devices PlutoSDR devices into autonomous OFDM transceivers with batman-adv mesh networking. It runs on the PlutoSDR's ARM processor (Xilinx Zynq-7000 Cortex-A9) and implements a 1.4 MHz OFDM-128 QPSK wireless physical layer, providing layer-2 mesh routing for TCP/IP traffic between host systems over ISM bands (915 MHz or 2.4 GHz).
+Charon is an embedded C application that transforms Analog Devices PlutoSDR devices into autonomous OFDM transceivers with batman-adv mesh networking. It runs on the PlutoSDR's ARM processor (Xilinx Zynq-7000 Cortex-A9) and implements a 1.4 MHz OFDM-64 QPSK wireless physical layer with CW-tone-based CFO estimation, providing layer-2 mesh routing for TCP/IP traffic between host systems over ISM bands (915 MHz or 2.4 GHz).
 
 Named after one of Pluto's moons.
 
@@ -60,7 +60,10 @@ timers.c          Microsecond-resolution timers (gettimeofday-based)
 glibc_compat.c    glibc compatibility shims — wraps __isoc23_strtol, __isoc23_strtoll,
                   __isoc23_strtoul, and __isoc23_strtoull via linker --wrap flags
 
-ofdm_conf.h       OFDM parameters (128 subcarriers, QPSK, FEC, 1x decimation)
+cw_tone.c         CW tone CFO estimator — TX generates 128-sample DC tone, RX detects
+                  via lag-64 autocorrelation and estimates carrier frequency offset
+
+ofdm_conf.h       OFDM parameters (64 subcarriers, QPSK, FEC, 1x decimation)
 ofdm.h            liquid-dsp internal struct definitions
 ethernet.h        Ethernet frame structures
 
@@ -81,10 +84,23 @@ deploy_callgrind.sh             Script to deploy and run Callgrind/Valgrind prof
 ## Signal Flow
 
 ```
-RX: AD9361 IQ samples -> pluto.c -> ofdm_rx.c (demodulate) -> tap_device.c -> Linux stack
-TX: tap_device.c -> ofdm_tx.c (modulate) -> pluto.c -> AD9361 RF output
+RX: AD9361 IQ samples -> pluto.c -> ofdm_rx.c (CW tone CFO + demodulate) -> tap_device.c -> Linux stack
+TX: tap_device.c -> ofdm_tx.c (CW tone + modulate) -> pluto.c -> AD9361 RF output
 MAC: charon.c manages frame queueing, ACK tracking, retransmission, batman frame wrapping
 ```
+
+### CFO Estimation (`cw_tone.c`)
+
+A single CW (continuous wave) DC tone is used for carrier frequency offset estimation,
+replacing the earlier PSS Zadoff-Chu correlator which was too CPU-intensive for the Cortex-A9.
+
+- **TX**: 128 samples of DC tone (`1.0 + 0.0j`) transmitted before each OFDM frame
+- **RX**: While in SEEKPLCP state, a lag-64 autocorrelation detects the tone and estimates CFO:
+  `cfo = arg(R(64)) / (2*pi*64)` in cycles/sample
+- **Detection threshold**: Normalized autocorrelation metric `|R|/(P/2)` >= 0.85
+- **Correction**: CFO applied to liquid-dsp NCO and hardware XO (`pluto_apply_pss_xo_correction`)
+- **Cost**: ~4 multiply-adds per sample (vs ~441 for the old PSS multi-hypothesis correlator)
+- **Over-the-air frame**: `[CW tone 128 samples] [OFDM PLCP + data]`
 
 ### MAC Layer Detail (`charon.c`)
 
@@ -143,8 +159,8 @@ MAC: charon.c manages frame queueing, ACK tracking, retransmission, batman frame
 
 | Parameter | Value | Notes |
 |-----------|-------|-------|
-| `OFDM_M` | 128 | Subcarrier count |
-| `CP_LEN` | 4 | Cyclic prefix length (samples) |
+| `OFDM_M` | 64 | Subcarrier count |
+| `CP_LEN` | 16 | Cyclic prefix length (samples) |
 | `TAPER_LEN` | 2 | Taper length (samples) |
 | `DECIMATE_INTERPOLATE_FACTOR` | 1 | Software oversampling ratio (hardware FIR handles decimation) |
 | `OFDM_MODULATION` | `LIQUID_MODEM_QPSK` | Production modulation |

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ PLATFORM := $(shell uname -s)
 
 
 OUT_DIR := .build
-ALL_SRC := $(wildcard charon.c config.c crc.c glibc_compat.c ofdm_rx.c ofdm_tx.c pss_sync.c tap_device.c tcp_subs.c timers.c util.c)
+ALL_SRC := $(wildcard charon.c config.c crc.c cw_tone.c glibc_compat.c ofdm_rx.c ofdm_tx.c tap_device.c tcp_subs.c timers.c util.c)
 SRC := $(ALL_SRC) pluto.c
 OBJ_ := $(SRC:$(SUFFIX)=.o)
 OBJ := $(addprefix $(OUT_DIR)/,$(OBJ_))

--- a/Makefile.host
+++ b/Makefile.host
@@ -28,7 +28,7 @@ PLATFORM := $(shell uname -s)
 
 OUT_DIR := .build_host
 # Get all source files, explicitly excluding pluto.c and pluto_host.c from wildcard
-ALL_SRC := $(wildcard charon.c config.c crc.c glibc_compat.c ofdm_rx.c ofdm_tx.c pss_sync.c tap_device.c tcp_subs.c timers.c util.c)
+ALL_SRC := $(wildcard charon.c config.c crc.c cw_tone.c glibc_compat.c ofdm_rx.c ofdm_tx.c tap_device.c tcp_subs.c timers.c util.c)
 # Add pluto_host.c (not pluto.c)
 SRC := $(ALL_SRC) pluto_host.c
 OBJ_ := $(SRC:$(SUFFIX)=.o)

--- a/cw_tone.c
+++ b/cw_tone.c
@@ -1,0 +1,167 @@
+//MIT License
+//
+//Copyright (c) 2018 tvelliott
+//
+//Permission is hereby granted, free of charge, to any person obtaining a copy
+//of this software and associated documentation files (the "Software"), to deal
+//in the Software without restriction, including without limitation the rights
+//to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//copies of the Software, and to permit persons to whom the Software is
+//furnished to do so, subject to the following conditions:
+//
+//The above copyright notice and this permission notice shall be included in all
+//copies or substantial portions of the Software.
+//
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//SOFTWARE.
+
+// Single CW (continuous wave) tone for carrier frequency offset estimation.
+//
+// TX side: cw_tone_get_tx_samples() fills a buffer with CW_TONE_LEN samples
+// of a DC tone (1.0 + 0.0j).  The tone is transmitted before the OFDM frame.
+//
+// RX side: cw_tone_execute() processes one sample at a time.  It maintains a
+// circular buffer of CW_TONE_LEN samples and computes a lag-CW_TONE_HALF
+// autocorrelation.  A pure tone produces |R(D)|/(P/2) ~ 1.0; when this metric
+// exceeds CW_TONE_CORR_THRESH the tone is declared detected and the CFO is
+// estimated from the autocorrelation phase:
+//   cfo = arg(R(D)) / (2*pi*D)   cycles/sample
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <complex.h>
+
+#include "ofdm_conf.h"
+#include "cw_tone.h"
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+#define CW_TONE_LEN          128
+#define CW_TONE_HALF         (CW_TONE_LEN / 2)
+#define CW_TONE_CORR_THRESH  0.85f
+#define CW_TONE_PWR_THRESH   1e-6f
+
+// ---------------------------------------------------------------------------
+// Module state
+// ---------------------------------------------------------------------------
+
+static float complex cw_buf[CW_TONE_LEN];
+static int           cw_buf_idx;
+static int           cw_sample_count;
+static float         cw_cfo_est;
+static float         cw_peak_metric;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////
+void cw_tone_init(void)
+{
+    fprintf(stderr, "\n[cw_tone] init: tone_len=%d half=%d thresh=%.2f",
+            CW_TONE_LEN, CW_TONE_HALF, CW_TONE_CORR_THRESH);
+    memset(cw_buf, 0, sizeof(cw_buf));
+    cw_buf_idx     = 0;
+    cw_sample_count = 0;
+    cw_cfo_est     = 0.0f;
+    cw_peak_metric = 0.0f;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////
+void cw_tone_reset(void)
+{
+    memset(cw_buf, 0, sizeof(cw_buf));
+    cw_buf_idx     = 0;
+    cw_sample_count = 0;
+    cw_cfo_est     = 0.0f;
+    cw_peak_metric = 0.0f;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Process one incoming IQ sample.
+//
+// Maintains a circular buffer of CW_TONE_LEN samples.  Once the buffer is
+// full, computes the lag-CW_TONE_HALF autocorrelation R and total power P.
+// If the normalized metric |R|/(P/2) exceeds threshold, the tone is detected
+// and CFO is estimated from arg(R).
+//
+// Returns 1 if tone detected, 0 otherwise.
+////////////////////////////////////////////////////////////////////////////////////////////////////////
+int cw_tone_execute(float complex sample)
+{
+    int n;
+
+    cw_buf[cw_buf_idx] = sample;
+    cw_buf_idx = (cw_buf_idx + 1) % CW_TONE_LEN;
+
+    if (cw_sample_count < CW_TONE_LEN) {
+        cw_sample_count++;
+        return 0;
+    }
+
+    // Compute lag-D autocorrelation: R = sum( x[n] * conj(x[n+D]) )
+    // and total power P = sum( |x[n]|^2 )
+    float complex autocorr = 0.0f + 0.0f * _Complex_I;
+    float power = 0.0f;
+
+    for (n = 0; n < CW_TONE_HALF; n++) {
+        int idx_early = (cw_buf_idx + n) % CW_TONE_LEN;
+        int idx_late  = (cw_buf_idx + n + CW_TONE_HALF) % CW_TONE_LEN;
+        autocorr += cw_buf[idx_late] * conjf(cw_buf[idx_early]);
+    }
+
+    for (n = 0; n < CW_TONE_LEN; n++)
+        power += crealf(cw_buf[n] * conjf(cw_buf[n]));
+
+    if (power < CW_TONE_PWR_THRESH)
+        return 0;
+
+    float metric = cabsf(autocorr) / (power / 2.0f);
+    cw_peak_metric = metric;
+
+    if (metric >= CW_TONE_CORR_THRESH) {
+        cw_cfo_est = cargf(autocorr) / (2.0f * (float)M_PI * (float)CW_TONE_HALF);
+        cw_sample_count = 0;  // reset to avoid re-triggering on same tone
+        return 1;
+    }
+
+    return 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////
+float cw_tone_get_freq_offset(void)
+{
+    return cw_cfo_est;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////
+float cw_tone_get_peak(void)
+{
+    return cw_peak_metric;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Fill *buf with CW_TONE_LEN samples of a DC tone (1.0 + 0.0j).
+// *len is set to the total number of complex samples written.
+////////////////////////////////////////////////////////////////////////////////////////////////////////
+void cw_tone_get_tx_samples(float complex *buf, int *len)
+{
+    int i;
+    for (i = 0; i < CW_TONE_LEN; i++)
+        buf[i] = 1.0f + 0.0f * _Complex_I;
+    *len = CW_TONE_LEN;
+    fprintf(stderr, "\n[cw_tone] get_tx_samples: len=%d", *len);
+}

--- a/cw_tone.h
+++ b/cw_tone.h
@@ -1,0 +1,10 @@
+/* This file was automatically generated.  Do not edit! */
+
+#define CW_TONE_TX_MAX_SAMPLES  128
+
+void cw_tone_init(void);
+void cw_tone_reset(void);
+int cw_tone_execute(float complex sample);
+float cw_tone_get_freq_offset(void);
+float cw_tone_get_peak(void);
+void cw_tone_get_tx_samples(float complex *buf,int *len);

--- a/ofdm_rx.c
+++ b/ofdm_rx.c
@@ -42,7 +42,7 @@
 #include "crc.h"
 #include "ethernet.h"
 #include "config.h"
-#include "pss_sync.h"
+#include "cw_tone.h"
 
 static unsigned int M = OFDM_M;        // number of subcarriers
 static unsigned int cp_len = CP_LEN;   // cyclic prefix length
@@ -367,7 +367,7 @@ void init_ofdm_rx(void) {
   _q  = fs;
   _qq = _q->fs;
 
-  pss_sync_init();
+  cw_tone_init();
 
   //ofdm_nco = nco_crcf_create(LIQUID_NCO);
   //nco_crcf_set_frequency(ofdm_nco, 0); 
@@ -383,8 +383,8 @@ void do_ofdm_rx(float complex sample) {
   // the AD9361 xo_correction (40 MHz base clock) so the hardware LO and
   // sample rates converge toward the correct values.
   if (_qq->state == OFDMFRAMESYNC_STATE_SEEKPLCP) {
-    if (pss_sync_execute(sample)) {
-      float cfo = pss_sync_get_freq_offset();   // cycles/sample
+    if (cw_tone_execute(sample)) {
+      float cfo = cw_tone_get_freq_offset();   // cycles/sample
       nco_crcf_set_frequency(_qq->nco_rx, 2.0f * (float)M_PI * cfo);
       if (cfo != 0.0f) {
         pluto_apply_pss_xo_correction(cfo);
@@ -392,10 +392,10 @@ void do_ofdm_rx(float complex sample) {
         // reset the internal NCO so it doesn't double-correct.
         nco_crcf_set_frequency(_qq->nco_rx, 0.0f);
       }
-      fprintf(stderr, "\nPSS: detected CFO=%.6f rad/samp (hyp %+d sc, peak=%.3f)",
+      fprintf(stderr, "\nCW_TONE: CFO=%.6f rad/samp (%.1f Hz, metric=%.3f)",
               2.0f * (float)M_PI * cfo,
-              (int)(cfo * (float)OFDM_M + (cfo >= 0.0f ? 0.5f : -0.5f)),
-              pss_sync_get_peak());
+              cfo * (float)sample_freq_hz,
+              cw_tone_get_peak());
     }
   }
   ofdmflexframesync_execute(fs, &sample, 1);

--- a/ofdm_tx.c
+++ b/ofdm_tx.c
@@ -37,7 +37,7 @@
 #include "pluto.h"
 #include "ethernet.h"
 #include "tap_device.h"
-#include "pss_sync.h"
+#include "cw_tone.h"
 
 static unsigned int ofdm_M;
 static unsigned int ofdm_cp_len;
@@ -152,19 +152,15 @@ int do_ofdm_tx( uint8_t *buffer, int len, int is_retrans, int do_dump_rx, int is
 do_send:
   timer_reset(timer1);
 
-  // Transmit PSS preamble (LTE-style Zadoff-Chu sequence with multiple
-  // frequency offset hypotheses on the receiver side).  This allows the
-  // remote receiver to acquire coarse CFO before the OFDM PLCP kicks in.
-  // The PSS (PSS_TX_MAX_SAMPLES = 126 samples) is sent in OFDM_M+CP_LEN
-  // chunks because pluto_transmit() operates at that hardware buffer
-  // granularity; the final chunk is zero-padded to fill the slot.
+  // Transmit CW tone for coarse CFO estimation.  The tone precedes the
+  // OFDM frame so the remote receiver can acquire frequency offset before
+  // the OFDM PLCP kicks in.
   {
-    static float complex pss_buf[PSS_TX_MAX_SAMPLES];
-    int pss_len = 0;
-    int pi;
-    pss_sync_get_tx_samples(pss_buf, &pss_len);
-    fprintf(stderr, "\n[ofdm_tx] PSS preamble: pss_len=%d", pss_len);
-    pluto_transmit(pss_buf, pss_len, 0, 0);
+    static float complex cw_buf[CW_TONE_TX_MAX_SAMPLES];
+    int cw_len = 0;
+    cw_tone_get_tx_samples(cw_buf, &cw_len);
+    fprintf(stderr, "\n[ofdm_tx] CW tone: cw_len=%d", cw_len);
+    pluto_transmit(cw_buf, cw_len, 0, 0);
   }
 
   ofdmflexframegen_assemble(ofdm_fg, ofdm_header, ofdm_payload, tlen);


### PR DESCRIPTION
The PSS Zadoff-Chu correlator ran 7 frequency hypotheses × 63 samples
per incoming sample, which was too CPU-intensive for the Cortex-A9.
Replace it with a single CW tone (128 samples of DC) that uses lag-64
autocorrelation for CFO estimation — roughly 100x cheaper per sample.

TX: 128 samples of 1.0+0j transmitted before the OFDM frame.
RX: Detect tone via normalized autocorrelation metric >= 0.85, estimate
CFO from arg(R(64)) / (2*pi*64) in cycles/sample. XO correction reused.

https://claude.ai/code/session_014nugNCSSjr9zzYYEAHVEQN