### PR TITLE
Add CW tone CFO, unit test suite, and update CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,13 +21,13 @@ make
 ```bash
 make host
 ```
-This produces `charon-host`, which replaces RF hardware with UDP sockets (both TX and RX on port 5002 at `127.0.0.1`). See `HOST_MODE.md` for integration details.
+This produces `charon-host`, which connects to a remote PlutoSDR over the network via libiio (IIO daemon). All RF operations (AD9361 config, IQ streaming, gain, AGC) work identically to on-device — the difference is IIO commands travel over the network. See `HOST_MODE.md` for URI options and integration details.
 
 ### Build example programs
 ```bash
 cd example && make
 ```
-Builds `ofdm_loopback_example` (TX/RX loopback test) and `ofdm_file_transfer` (multi-frame simulation). Note: examples use QAM-16 modulation for demonstration; production Charon uses QPSK (see `ofdm_conf.h`).
+Builds `ofdm_loopback_example` (TX/RX loopback test), `ofdm_file_transfer` (multi-frame simulation), `pss_sync_example` (PSS frequency-offset sync demo), and `ofdm_channel_test` (channel impairment test). Note: examples use QAM-16 modulation for demonstration; production Charon uses QPSK (see `ofdm_conf.h`).
 
 ### Full firmware image
 ```bash
@@ -47,7 +47,7 @@ make -f Makefile.host clean  # Host build artifacts in .build_host/
 ```
 charon.c          Main event loop, MAC layer (CSMA/LBT), ACK/retransmission state machine
 pluto.c           PlutoSDR hardware interface via libiio/AD9361 (AGC, frequency, gain)
-pluto_host.c      Host-mode replacement: UDP sockets instead of hardware
+pluto_host.c      Host-mode replacement: remote PlutoSDR via libiio network context
 ofdm_tx.c         OFDM frame modulation using liquid-dsp ofdmflexframegen
 ofdm_rx.c         OFDM frame demodulation using liquid-dsp ofdmflexframesync
 tap_device.c      TAP network device (ofdm0) creation, bridge setup, frame wrapping
@@ -62,6 +62,7 @@ glibc_compat.c    glibc compatibility shims — wraps __isoc23_strtol, __isoc23_
 
 cw_tone.c         CW tone CFO estimator — TX generates 128-sample DC tone, RX detects
                   via lag-64 autocorrelation and estimates carrier frequency offset
+pss_sync.c        Legacy PSS Zadoff-Chu correlator (replaced by cw_tone.c, retained for reference)
 
 ofdm_conf.h       OFDM parameters (64 subcarriers, QPSK, FEC, 1x decimation)
 ofdm.h            liquid-dsp internal struct definitions
@@ -75,6 +76,15 @@ example/          Host-mode loopback and file transfer examples
   test.sh         Automated test script
   benchmark.sh    Throughput benchmark script
 
+tests/            Unit test suite (CRC, TCP, timers, CW tone, channel simulation)
+  test_harness.h  Minimal assert-based test framework (no external dependencies)
+  test_crc.c      CRC-32 correctness tests
+  test_tcp_subs.c TCP MSS/window rewriting tests
+  test_timers.c   Microsecond timer tests
+  test_cw_tone.c  CW tone generation and detection tests
+  test_cw_tone_channel.c  CW tone under channel impairments (CFO, noise, multipath)
+
+deploy.sh         Script to deploy charon binary to PlutoSDR via SSH
 build_pluto_image/              Helper scripts/configs for PlutoSDR firmware builds
 changes_to_plutosdr_fw_configs_rel_to_v28/  Diffs of config changes vs firmware v0.28
 buildroot_static_libs.patch     Patch enabling static library builds in buildroot
@@ -137,7 +147,7 @@ replacing the earlier PSS Zadoff-Chu correlator which was too CPU-intensive for 
 
 ### Build Targets
 - `Makefile` — ARM cross-compilation with Linaro GCC (`arm-linux-gnueabihf-gcc`)
-  - Compiler flags: `-O2 -std=gnu99 -mcpu=cortex-a9 -mfpu=neon -mfloat-abi=hard -ggdb -D_TIME_BITS=32 -fno-builtin-strtol`
+  - Compiler flags: `-O2 -flto -std=gnu99 -mcpu=cortex-a9 -mfpu=neon -mfloat-abi=hard -ggdb -D_TIME_BITS=32 -fno-builtin-strtol`
   - Output directory: `.build/`
   - Statically links: libliquid.a, libfftw3f.a, libfec, libtuntap
   - Dynamically links: libc, libiio, libad9361, libini, libusb-1.0, libserialport, libavahi-client, libavahi-common, libxml2, libz, libdbus-1
@@ -145,7 +155,12 @@ replacing the earlier PSS Zadoff-Chu correlator which was too CPU-intensive for 
 - `Makefile.host` — Native host build with system gcc
   - Compiler flags: `-O0 -std=gnu99 -ggdb -D_FILE_OFFSET_BITS=64`
   - Output directory: `.build_host/`
-  - Uses `pluto_host.c` instead of `pluto.c`
+  - Uses `pluto_host.c` instead of `pluto.c` (remote IIO via network)
+  - Dynamically links all libraries (libiio, libad9361, liquid-dsp, fftw3, etc.)
+- `tests/Makefile` — Unit tests with system gcc
+  - Compiler flags: `-Wall -Wextra -O0 -g -std=gnu99`
+  - Each test `#include`s the source `.c` directly — no separate library step
+  - `make check` builds and runs all tests
 
 ### Key Dependencies
 - **liquid-dsp** — OFDM PHY layer (ofdmflexframegen, ofdmflexframesync, FIR filters)
@@ -178,37 +193,47 @@ replacing the earlier PSS Zadoff-Chu correlator which was too CPU-intensive for 
 
 ## Testing
 
-There is no traditional unit test suite. Testing is done through:
+### Unit tests (`tests/` directory)
+```bash
+cd tests && make check
+```
+- Self-contained C tests using a minimal assert-based harness (`test_harness.h`)
+- Each test file `#include`s the `.c` under test directly, allowing access to `static` functions
+- No external dependencies beyond the standard library and `-lm`
+- Tests: `test_crc`, `test_tcp_subs`, `test_timers`, `test_cw_tone`, `test_cw_tone_channel`
+- CI runs these first; build proceeds only if all pass
 
-1. **Example programs** (`example/` directory):
-   - `ofdm_loopback_example` — validates OFDM TX/RX in loopback without RF (uses QAM-16)
-   - `ofdm_file_transfer` — simulates multi-frame file transfer
-   - Run: `cd example && make && ./ofdm_loopback_example`
-   - Automated tests: `cd example && ./test.sh`
+### Example programs (`example/` directory)
+- `ofdm_loopback_example` — validates OFDM TX/RX in loopback without RF (uses QAM-16)
+- `ofdm_file_transfer` — simulates multi-frame file transfer
+- `pss_sync_example` — PSS Zadoff-Chu sync demonstration
+- `ofdm_channel_test` — OFDM under channel impairments
+- Run: `cd example && make && ./ofdm_loopback_example`
+- Automated tests: `cd example && ./test.sh`
 
-2. **Host mode** (`make host`):
-   - Produces `charon-host` using UDP sockets instead of RF hardware
-   - TX sends OFDM baseband IQ samples (int16_t pairs) to `127.0.0.1:5002`
-   - RX receives OFDM baseband IQ samples (int16_t pairs) from `127.0.0.1:5002`
-   - No software FIR stage — samples are at the OFDM baseband rate (1.4 MHz equivalent)
-   - External GNU Radio / SDR++ integrations must provide their own interpolation/decimation to match hardware sample rates
-   - TX destination is automatically learned from the first RX packet source address
-   - See `HOST_MODE.md` for details and integration examples
+### Host mode (`make host`)
+- Produces `charon-host` connecting to a remote PlutoSDR via libiio network context
+- All RF control (AD9361 config, IQ streaming, gain, AGC, frequency) works over the network
+- Specify PlutoSDR URI: `sudo ./charon-host --uri ip:192.168.2.1`
+- IQ recording/playback: `--save-tx <file>` and `--load-rx <file>`
+- See `HOST_MODE.md` for URI formats and integration details
 
-3. **On-device testing** (via SSH):
-   - `ssh root@192.168.2.1` (password: `analog`)
-   - Restart: `/etc/init.d/S100-start_charon restart`
-   - Performance: `iperf3 -c <remote_ip>` (iperf3 server auto-starts on PlutoSDR)
+### On-device testing (via SSH)
+- `ssh root@192.168.2.1` (password: `analog`)
+- Restart: `/etc/init.d/S100-start_charon restart`
+- Performance: `iperf3 -c <remote_ip>` (iperf3 server auto-starts on PlutoSDR)
 
-4. **Profiling** (`deploy_callgrind.sh`):
-   - Deploys and runs Callgrind/Valgrind on-device for performance analysis
+### Profiling (`deploy_callgrind.sh`)
+- Deploys and runs Callgrind/Valgrind on-device for performance analysis
 
-5. **CI** (`.github/workflows/nomod.yml`):
-   - GitHub Actions on ubuntu-24.04
-   - Applies `buildroot_static_libs.patch` to buildroot before building
-   - Builds cross-compiled binary, then full firmware image
-   - Uploads artifacts: `charon` binary, `out.txt` disassembly, and `plutosdr-fw/build/` firmware
-   - Triggered on push/PR to `master` and `dev` branches, and manual dispatch
+### CI (`.github/workflows/nomod.yml`)
+- GitHub Actions on ubuntu-24.04
+- **Stage 1**: Builds and runs unit tests (`cd tests && make check`)
+- **Stage 2** (after tests pass): Cross-compiles charon binary with full toolchain
+- **Stage 3**: Builds full PlutoSDR firmware image
+- Applies `buildroot_static_libs.patch` to buildroot before building
+- Uploads artifacts: `charon` binary, `out.txt` disassembly, and `plutosdr-fw/build/` firmware
+- Triggered on push/PR to `master` and `dev` branches, and manual dispatch
 
 ## Runtime Configuration
 

--- a/tests/test_cw_tone_channel.c
+++ b/tests/test_cw_tone_channel.c
@@ -537,6 +537,457 @@ static void test_channel_multipath_longer_delay(void)
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// Large CFO tests (100 kHz at 1.4 MHz sample rate)
+///////////////////////////////////////////////////////////////////////////////
+
+static void test_channel_cfo_100khz(void)
+{
+    TEST_BEGIN("channel: 100 kHz CFO aliases outside unambiguous range");
+    // 100 kHz at 1.4 MHz sample rate = 0.0714 cycles/sample
+    // Unambiguous range is ±1/(2*64) = ±0.0078 cycles/sample (±10.9 kHz)
+    // 100 kHz is ~9x outside this range — estimate will alias.
+    srand(10000);
+    float target_cfo = 100000.0f / 1400000.0f;  // 0.0714 cycles/sample
+    float est_cfo;
+    int det = feed_impaired_tone(target_cfo, 0.0f, 40.0f, 1.0f, &est_cfo);
+    // The tone should still be detected (autocorrelation magnitude is high)
+    // but the estimated CFO will be aliased into [-0.0078, +0.0078]
+    if (det) {
+        char msg[128];
+        snprintf(msg, sizeof(msg),
+                 "aliased CFO %.6f should be within unambiguous range", est_cfo);
+        TEST_ASSERT_MSG(fabsf(est_cfo) <= 0.0079f, msg);
+        // Verify it does NOT equal the true 100 kHz offset
+        TEST_ASSERT_MSG(fabsf(est_cfo - target_cfo) > 0.01f,
+                        "estimate should NOT match true 100 kHz offset");
+    }
+    // Detection may or may not happen depending on aliased phase coherence
+    TEST_PASS();
+}
+
+static void test_channel_cfo_100khz_negative(void)
+{
+    TEST_BEGIN("channel: -100 kHz CFO aliases outside unambiguous range");
+    srand(10001);
+    float target_cfo = -100000.0f / 1400000.0f;
+    float est_cfo;
+    int det = feed_impaired_tone(target_cfo, 0.0f, 40.0f, 1.0f, &est_cfo);
+    if (det) {
+        char msg[128];
+        snprintf(msg, sizeof(msg),
+                 "aliased CFO %.6f should be within unambiguous range", est_cfo);
+        TEST_ASSERT_MSG(fabsf(est_cfo) <= 0.0079f, msg);
+    }
+    TEST_PASS();
+}
+
+static void test_channel_cfo_100khz_noisy(void)
+{
+    TEST_BEGIN("channel: 100 kHz CFO with 20 dB noise");
+    srand(10002);
+    float target_cfo = 100000.0f / 1400000.0f;
+    float est_cfo;
+    int det = feed_impaired_tone(target_cfo, 0.0f, 20.0f, 1.0f, &est_cfo);
+    if (det) {
+        TEST_ASSERT_MSG(fabsf(est_cfo) <= 0.0079f,
+                        "aliased estimate should stay in unambiguous range");
+    }
+    TEST_PASS();
+}
+
+static void test_channel_cfo_near_edge(void)
+{
+    TEST_BEGIN("channel: CFO at ±10 kHz (near unambiguous edge)");
+    // 10 kHz / 1.4 MHz = 0.00714 cycles/sample — just inside ±0.0078
+    float cfo_10k = 10000.0f / 1400000.0f;
+    for (int sign = -1; sign <= 1; sign += 2) {
+        float target = (float)sign * cfo_10k;
+        srand(10100 + sign);
+        float est_cfo;
+        int det = feed_impaired_tone(target, 0.0f, 30.0f, 1.0f, &est_cfo);
+        char msg[128];
+        snprintf(msg, sizeof(msg),
+                 "10 kHz (%+.6f): det=%d est=%.6f err=%.6f",
+                 target, det, est_cfo, fabsf(est_cfo - target));
+        TEST_ASSERT_MSG(det, msg);
+        TEST_ASSERT_MSG(fabsf(est_cfo - target) < 0.002f, msg);
+    }
+    TEST_PASS();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Sync timing tests — verify detection fires at the correct sample position
+///////////////////////////////////////////////////////////////////////////////
+
+static void test_sync_detection_timing(void)
+{
+    TEST_BEGIN("sync: detection fires within expected sample window");
+    cw_tone_init();
+
+    // Feed exactly 128 DC tone samples. Detection requires filling the
+    // circular buffer (128 samples) then one full autocorrelation window.
+    // Detection should fire at or near sample 128.
+    int detect_sample = -1;
+    for (int n = 0; n < 256; n++) {
+        if (cw_tone_execute(1.0f + 0.0f * _Complex_I)) {
+            detect_sample = n;
+            break;
+        }
+    }
+    char msg[128];
+    snprintf(msg, sizeof(msg), "detected at sample %d (expected ~128)", detect_sample);
+    TEST_ASSERT_MSG(detect_sample >= 0, "tone should be detected");
+    // Should detect at sample 128 (after buffer fills)
+    TEST_ASSERT_MSG(detect_sample == 128, msg);
+    TEST_PASS();
+}
+
+static void test_sync_detection_after_noise_gap(void)
+{
+    TEST_BEGIN("sync: detection timing correct after noise gap");
+    cw_tone_init();
+    srand(11001);
+
+    int noise_len = 300;
+    int tone_start = noise_len;  // tone starts at this sample index
+    int detect_sample = -1;
+
+    for (int n = 0; n < noise_len + 512; n++) {
+        float complex sample;
+        if (n < noise_len) {
+            // Low-level noise
+            float re = ((float)rand() / RAND_MAX) * 0.1f - 0.05f;
+            float im = ((float)rand() / RAND_MAX) * 0.1f - 0.05f;
+            sample = re + im * _Complex_I;
+        } else {
+            sample = 1.0f + 0.0f * _Complex_I;
+        }
+
+        if (detect_sample < 0 && cw_tone_execute(sample)) {
+            detect_sample = n;
+        }
+    }
+
+    char msg[128];
+    snprintf(msg, sizeof(msg),
+             "detected at sample %d, tone starts at %d, delta=%d",
+             detect_sample, tone_start, detect_sample - tone_start);
+    TEST_ASSERT_MSG(detect_sample >= 0, "should detect tone after noise gap");
+    // Detection comes after the circular buffer fills with mostly-tone samples.
+    // With residual noise in the buffer, detection can fire slightly before
+    // the full 128-sample fill, so allow a window from ~100 to ~196.
+    int delta = detect_sample - tone_start;
+    TEST_ASSERT_MSG(delta >= 100 && delta <= 196, msg);
+    TEST_PASS();
+}
+
+static void test_sync_no_early_trigger(void)
+{
+    TEST_BEGIN("sync: no false trigger during partial tone fill");
+    cw_tone_init();
+
+    // Feed only 127 DC samples — should NOT trigger
+    int detected = 0;
+    for (int n = 0; n < 127; n++) {
+        if (cw_tone_execute(1.0f + 0.0f * _Complex_I)) {
+            detected = 1;
+        }
+    }
+    TEST_ASSERT_MSG(!detected, "should not detect with only 127 samples");
+    TEST_PASS();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Leading noise tests — noise before the tone
+///////////////////////////////////////////////////////////////////////////////
+
+static void test_leading_noise_low_level(void)
+{
+    TEST_BEGIN("leading noise: low-level noise before tone");
+    cw_tone_init();
+    srand(12000);
+
+    float target_cfo = 0.003f;
+    int detected = 0;
+    float est_cfo = 0.0f;
+    int noise_len = 500;
+
+    for (int n = 0; n < noise_len + 512; n++) {
+        float complex sample;
+        if (n < noise_len) {
+            float re = ((float)rand() / RAND_MAX) * 0.2f - 0.1f;
+            float im = ((float)rand() / RAND_MAX) * 0.2f - 0.1f;
+            sample = re + im * _Complex_I;
+        } else {
+            int t = n - noise_len;
+            float phase = 2.0f * (float)M_PI * target_cfo * (float)t;
+            sample = cosf(phase) + sinf(phase) * _Complex_I;
+        }
+
+        if (!detected && cw_tone_execute(sample)) {
+            detected = 1;
+            est_cfo = cw_tone_get_freq_offset();
+        }
+    }
+
+    TEST_ASSERT_MSG(detected, "should detect tone after low-level leading noise");
+    char msg[128];
+    snprintf(msg, sizeof(msg), "est=%.6f target=%.6f", est_cfo, target_cfo);
+    TEST_ASSERT_MSG(fabsf(est_cfo - target_cfo) < 0.002f, msg);
+    TEST_PASS();
+}
+
+static void test_leading_noise_high_level(void)
+{
+    TEST_BEGIN("leading noise: high-level noise before tone");
+    cw_tone_init();
+    srand(12001);
+
+    float target_cfo = -0.002f;
+    int detected = 0;
+    float est_cfo = 0.0f;
+    int noise_len = 400;
+
+    for (int n = 0; n < noise_len + 512; n++) {
+        float complex sample;
+        if (n < noise_len) {
+            // Noise at same power as tone
+            float re = ((float)rand() / RAND_MAX) * 2.0f - 1.0f;
+            float im = ((float)rand() / RAND_MAX) * 2.0f - 1.0f;
+            sample = re + im * _Complex_I;
+        } else {
+            int t = n - noise_len;
+            float phase = 2.0f * (float)M_PI * target_cfo * (float)t;
+            sample = cosf(phase) + sinf(phase) * _Complex_I;
+        }
+
+        if (!detected && cw_tone_execute(sample)) {
+            detected = 1;
+            est_cfo = cw_tone_get_freq_offset();
+        }
+    }
+
+    TEST_ASSERT_MSG(detected, "should detect tone after high-level leading noise");
+    char msg[128];
+    snprintf(msg, sizeof(msg), "est=%.6f target=%.6f", est_cfo, target_cfo);
+    TEST_ASSERT_MSG(fabsf(est_cfo - target_cfo) < 0.002f, msg);
+    TEST_PASS();
+}
+
+static void test_leading_noise_no_false_trigger(void)
+{
+    TEST_BEGIN("leading noise: no false detection during noise-only segment");
+    cw_tone_init();
+    srand(12002);
+
+    int false_trigger = 0;
+    int noise_len = 1000;
+
+    // Feed only noise — no tone at all
+    for (int n = 0; n < noise_len; n++) {
+        float re = ((float)rand() / RAND_MAX) * 2.0f - 1.0f;
+        float im = ((float)rand() / RAND_MAX) * 2.0f - 1.0f;
+        if (cw_tone_execute(re + im * _Complex_I)) {
+            false_trigger = 1;
+            break;
+        }
+    }
+    TEST_ASSERT_MSG(!false_trigger, "should not false-trigger on noise-only input");
+    TEST_PASS();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Lagging noise tests — noise after the tone
+///////////////////////////////////////////////////////////////////////////////
+
+static void test_lagging_noise_low_level(void)
+{
+    TEST_BEGIN("lagging noise: tone followed by low-level noise");
+    cw_tone_init();
+    srand(13000);
+
+    float target_cfo = 0.004f;
+    int detected = 0;
+    float est_cfo = 0.0f;
+    int tone_len = 192;
+
+    for (int n = 0; n < tone_len + 300; n++) {
+        float complex sample;
+        if (n < tone_len) {
+            float phase = 2.0f * (float)M_PI * target_cfo * (float)n;
+            sample = cosf(phase) + sinf(phase) * _Complex_I;
+        } else {
+            float re = ((float)rand() / RAND_MAX) * 0.2f - 0.1f;
+            float im = ((float)rand() / RAND_MAX) * 0.2f - 0.1f;
+            sample = re + im * _Complex_I;
+        }
+
+        if (!detected && cw_tone_execute(sample)) {
+            detected = 1;
+            est_cfo = cw_tone_get_freq_offset();
+        }
+    }
+
+    TEST_ASSERT_MSG(detected, "should detect tone before lagging noise arrives");
+    char msg[128];
+    snprintf(msg, sizeof(msg), "est=%.6f target=%.6f", est_cfo, target_cfo);
+    TEST_ASSERT_MSG(fabsf(est_cfo - target_cfo) < 0.002f, msg);
+    TEST_PASS();
+}
+
+static void test_lagging_noise_high_level(void)
+{
+    TEST_BEGIN("lagging noise: tone followed by high-level noise");
+    cw_tone_init();
+    srand(13001);
+
+    float target_cfo = -0.005f;
+    int detected = 0;
+    float est_cfo = 0.0f;
+    int tone_len = 192;
+
+    for (int n = 0; n < tone_len + 300; n++) {
+        float complex sample;
+        if (n < tone_len) {
+            float phase = 2.0f * (float)M_PI * target_cfo * (float)n;
+            sample = cosf(phase) + sinf(phase) * _Complex_I;
+        } else {
+            float re = ((float)rand() / RAND_MAX) * 2.0f - 1.0f;
+            float im = ((float)rand() / RAND_MAX) * 2.0f - 1.0f;
+            sample = re + im * _Complex_I;
+        }
+
+        if (!detected && cw_tone_execute(sample)) {
+            detected = 1;
+            est_cfo = cw_tone_get_freq_offset();
+        }
+    }
+
+    TEST_ASSERT_MSG(detected, "should detect tone before high-level lagging noise");
+    char msg[128];
+    snprintf(msg, sizeof(msg), "est=%.6f target=%.6f", est_cfo, target_cfo);
+    TEST_ASSERT_MSG(fabsf(est_cfo - target_cfo) < 0.002f, msg);
+    TEST_PASS();
+}
+
+static void test_lagging_noise_no_retrigger(void)
+{
+    TEST_BEGIN("lagging noise: no re-trigger during noise after detection");
+    cw_tone_init();
+    srand(13002);
+
+    int detect_count = 0;
+    int tone_len = 192;
+
+    for (int n = 0; n < tone_len + 500; n++) {
+        float complex sample;
+        if (n < tone_len) {
+            sample = 1.0f + 0.0f * _Complex_I;
+        } else {
+            float re = ((float)rand() / RAND_MAX) * 2.0f - 1.0f;
+            float im = ((float)rand() / RAND_MAX) * 2.0f - 1.0f;
+            sample = re + im * _Complex_I;
+        }
+
+        if (cw_tone_execute(sample))
+            detect_count++;
+    }
+
+    char msg[64];
+    snprintf(msg, sizeof(msg), "detect_count=%d (expect 1)", detect_count);
+    TEST_ASSERT_MSG(detect_count == 1, msg);
+    TEST_PASS();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Leading + lagging noise (sandwich)
+///////////////////////////////////////////////////////////////////////////////
+
+static void test_noise_sandwich(void)
+{
+    TEST_BEGIN("sandwich: noise-tone-noise with CFO");
+    cw_tone_init();
+    srand(14000);
+
+    float target_cfo = 0.006f;
+    int detected = 0;
+    float est_cfo = 0.0f;
+    int pre_noise = 400;
+    int tone_len = 192;
+    int post_noise = 400;
+    int total = pre_noise + tone_len + post_noise;
+
+    for (int n = 0; n < total; n++) {
+        float complex sample;
+        if (n < pre_noise || n >= pre_noise + tone_len) {
+            // Noise
+            float re = ((float)rand() / RAND_MAX) * 1.0f - 0.5f;
+            float im = ((float)rand() / RAND_MAX) * 1.0f - 0.5f;
+            sample = re + im * _Complex_I;
+        } else {
+            // Tone
+            int t = n - pre_noise;
+            float phase = 2.0f * (float)M_PI * target_cfo * (float)t;
+            sample = cosf(phase) + sinf(phase) * _Complex_I;
+        }
+
+        if (!detected && cw_tone_execute(sample)) {
+            detected = 1;
+            est_cfo = cw_tone_get_freq_offset();
+        }
+    }
+
+    TEST_ASSERT_MSG(detected, "should detect tone in noise sandwich");
+    char msg[128];
+    snprintf(msg, sizeof(msg), "est=%.6f target=%.6f err=%.6f",
+             est_cfo, target_cfo, fabsf(est_cfo - target_cfo));
+    TEST_ASSERT_MSG(fabsf(est_cfo - target_cfo) < 0.002f, msg);
+    TEST_PASS();
+}
+
+static void test_noise_sandwich_awgn(void)
+{
+    TEST_BEGIN("sandwich: noise-tone(+AWGN)-noise with CFO");
+    cw_tone_init();
+    srand(14001);
+
+    float target_cfo = -0.004f;
+    int detected = 0;
+    float est_cfo = 0.0f;
+    int pre_noise = 300;
+    int tone_len = 256;
+    int post_noise = 300;
+    int total = pre_noise + tone_len + post_noise;
+    float noise_sigma = 0.15f;  // ~16 dB SNR
+
+    for (int n = 0; n < total; n++) {
+        float complex sample;
+        if (n < pre_noise || n >= pre_noise + tone_len) {
+            float re = ((float)rand() / RAND_MAX) * 1.0f - 0.5f;
+            float im = ((float)rand() / RAND_MAX) * 1.0f - 0.5f;
+            sample = re + im * _Complex_I;
+        } else {
+            int t = n - pre_noise;
+            float phase = 2.0f * (float)M_PI * target_cfo * (float)t;
+            sample = cosf(phase) + sinf(phase) * _Complex_I;
+            sample += awgn(noise_sigma);
+        }
+
+        if (!detected && cw_tone_execute(sample)) {
+            detected = 1;
+            est_cfo = cw_tone_get_freq_offset();
+        }
+    }
+
+    TEST_ASSERT_MSG(detected, "should detect noisy tone in noise sandwich");
+    char msg[128];
+    snprintf(msg, sizeof(msg), "est=%.6f target=%.6f err=%.6f",
+             est_cfo, target_cfo, fabsf(est_cfo - target_cfo));
+    TEST_ASSERT_MSG(fabsf(est_cfo - target_cfo) < 0.003f, msg);
+    TEST_PASS();
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // Frequency drift (time-varying CFO)
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -615,6 +1066,31 @@ int main(void)
     // Multipath
     RUN_TEST(test_channel_multipath_short_delay);
     RUN_TEST(test_channel_multipath_longer_delay);
+
+    // Large CFO (100 kHz)
+    RUN_TEST(test_channel_cfo_100khz);
+    RUN_TEST(test_channel_cfo_100khz_negative);
+    RUN_TEST(test_channel_cfo_100khz_noisy);
+    RUN_TEST(test_channel_cfo_near_edge);
+
+    // Sync timing
+    RUN_TEST(test_sync_detection_timing);
+    RUN_TEST(test_sync_detection_after_noise_gap);
+    RUN_TEST(test_sync_no_early_trigger);
+
+    // Leading noise
+    RUN_TEST(test_leading_noise_low_level);
+    RUN_TEST(test_leading_noise_high_level);
+    RUN_TEST(test_leading_noise_no_false_trigger);
+
+    // Lagging noise
+    RUN_TEST(test_lagging_noise_low_level);
+    RUN_TEST(test_lagging_noise_high_level);
+    RUN_TEST(test_lagging_noise_no_retrigger);
+
+    // Noise sandwich (leading + lagging)
+    RUN_TEST(test_noise_sandwich);
+    RUN_TEST(test_noise_sandwich_awgn);
 
     // Drift
     RUN_TEST(test_channel_frequency_drift);


### PR DESCRIPTION
## Summary

- **CW tone CFO estimator** (`cw_tone.c`): Replaces PSS Zadoff-Chu correlator with a lightweight lag-64 autocorrelation on a 128-sample DC tone (~4 multiply-adds/sample vs ~441 for PSS)
- **Unit test suite** (`tests/`): 5 test binaries covering CRC, TCP MSS/window rewriting, timers, CW tone detection, and CW tone under channel impairments (AWGN, multipath, phase offsets, 100 kHz CFO aliasing, sync timing, leading/lagging noise)
- **CLAUDE.md**: Updated to reflect current codebase — remote IIO host mode (not UDP), unit test documentation, 3-stage CI pipeline, example programs, LTO flags
- **CI**: Added `unit-tests` stage that gates the cross-compile build

## Test plan

- [x] `cd tests && make check` — all 79 tests pass (12 CRC + 11 TCP + 7 timer + 10 CW tone + 39 CW tone channel)
- [ ] Verify CI passes on GitHub Actions
- [ ] Cross-compile with `make` succeeds

https://claude.ai/code/session_018Qtg7Cqd4AsKYd5E2x11Vx
