### PR TITLE
Move CW tone from DC to Fs/4 (350 kHz) and add 16-sample guard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,8 +52,9 @@ timers.c          Microsecond-resolution timers (gettimeofday-based)
 glibc_compat.c    glibc compatibility shims — wraps __isoc23_strtol, __isoc23_strtoll,
                   __isoc23_strtoul, and __isoc23_strtoull via linker --wrap flags
 
-cw_tone.c         CW tone CFO estimator — TX generates 128-sample DC tone, RX detects
-                  via lag-64 autocorrelation and estimates carrier frequency offset
+cw_tone.c         CW tone CFO estimator — TX generates 128-sample Fs/4 tone (350 kHz)
+                  plus 16-sample guard, RX detects via two-stage autocorrelation
+                  and estimates carrier frequency offset
 
 ofdm_conf.h       OFDM parameters (64 subcarriers, QPSK, FEC, 1x decimation)
 ofdm.h            liquid-dsp internal struct definitions
@@ -92,15 +93,19 @@ MAC: charon.c manages frame queueing, ACK tracking, retransmission, batman frame
 
 ### CFO Estimation (`cw_tone.c`)
 
-A single CW (continuous wave) DC tone is used for carrier frequency offset estimation.
+A single CW (continuous wave) tone at Fs/4 (350 kHz) is used for carrier frequency offset estimation.
+The tone is offset from DC to avoid carrier leakage in the AD9361 direct-conversion receiver.
 
-- **TX**: 128 samples of DC tone (`1.0 + 0.0j`) transmitted before each OFDM frame
-- **RX**: While in SEEKPLCP state, a lag-64 autocorrelation detects the tone and estimates CFO:
-  `cfo = arg(R(64)) / (2*pi*64)` in cycles/sample
+- **TX**: 128 samples of Fs/4 tone (0.25 cyc/samp) + 16-sample zero guard transmitted before each OFDM frame
+- **RX**: While in SEEKPLCP state, a two-stage autocorrelation detects the tone and estimates CFO:
+  - Stage 1 (coarse): lag-4, capture range ±175 kHz
+  - Stage 2 (fine): lag-64 on de-rotated signal, refines residual
+  - At f_tone=0.25, both `0.25*4=1` and `0.25*64=16` are integers, so the tone
+    frequency vanishes from the phase estimate — the estimator outputs true CFO directly
 - **Detection threshold**: Normalized autocorrelation metric `|R|/(P/2)` >= 0.85
 - **Correction**: CFO applied to liquid-dsp NCO and hardware XO (`pluto_apply_pss_xo_correction`)
 - **Cost**: ~4 multiply-adds per sample
-- **Over-the-air frame**: `[CW tone 128 samples] [OFDM PLCP + data]`
+- **Over-the-air frame**: `[CW tone 128 samples] [guard 16 zeros] [OFDM PLCP + data]`
 
 ### MAC Layer Detail (`charon.c`)
 

--- a/cw_tone.c
+++ b/cw_tone.c
@@ -23,7 +23,10 @@
 // Single CW (continuous wave) tone for carrier frequency offset estimation.
 //
 // TX side: cw_tone_get_tx_samples() fills a buffer with CW_TONE_LEN samples
-// of a DC tone (1.0 + 0.0j).  The tone is transmitted before the OFDM frame.
+// of a tone at Fs/4 (0.25 cycles/sample = 350 kHz at 1.4 MHz) followed by
+// CW_TONE_GUARD zero samples.  The tone is offset from DC to avoid carrier
+// leakage in the AD9361 direct-conversion receiver.  A guard interval of
+// zeros separates the CW tone from the OFDM preamble.
 //
 // RX side: cw_tone_execute() processes one sample at a time.  It maintains a
 // circular buffer of CW_TONE_LEN samples and computes a lag-CW_TONE_HALF
@@ -31,6 +34,11 @@
 // exceeds CW_TONE_CORR_THRESH the tone is declared detected and the CFO is
 // estimated from the autocorrelation phase:
 //   cfo = arg(R(D)) / (2*pi*D)   cycles/sample
+//
+// At CW_TONE_FREQ = 0.25 cyc/samp, the tone frequency is invisible to both
+// estimation stages because 0.25*4 = 1 and 0.25*64 = 16 are integers, so
+// exp(j*2*pi*f_tone*lag) = 1 for both lags.  The estimator naturally outputs
+// the true CFO with no bias or adjustment needed.
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -50,6 +58,8 @@
 #define CW_TONE_COARSE_LAG   4
 #define CW_TONE_CORR_THRESH  0.85f
 #define CW_TONE_PWR_THRESH   1e-6f
+#define CW_TONE_FREQ         0.25f   // cycles/sample (Fs/4 = 350 kHz at 1.4 MHz)
+#define CW_TONE_GUARD        16      // zero-sample guard between CW tone and OFDM preamble
 
 // ---------------------------------------------------------------------------
 // Module state
@@ -77,8 +87,8 @@ static float         cw_noise_floor;   // last valid noise floor (dB), survives 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 void cw_tone_init(void)
 {
-    fprintf(stderr, "\n[cw_tone] init: tone_len=%d coarse_lag=%d fine_lag=%d thresh=%.2f",
-            CW_TONE_LEN, CW_TONE_COARSE_LAG, CW_TONE_HALF, CW_TONE_CORR_THRESH);
+    fprintf(stderr, "\n[cw_tone] init: tone_len=%d guard=%d freq=%.2f coarse_lag=%d fine_lag=%d thresh=%.2f",
+            CW_TONE_LEN, CW_TONE_GUARD, CW_TONE_FREQ, CW_TONE_COARSE_LAG, CW_TONE_HALF, CW_TONE_CORR_THRESH);
     memset(cw_buf, 0, sizeof(cw_buf));
     cw_buf_idx     = 0;
     cw_sample_count = 0;
@@ -232,14 +242,25 @@ float cw_tone_get_noise_floor(void)
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
-// Fill *buf with CW_TONE_LEN samples of a DC tone (1.0 + 0.0j).
-// *len is set to the total number of complex samples written.
+// Fill *buf with CW_TONE_LEN samples of an Fs/4 tone (0.25 cyc/samp) followed
+// by CW_TONE_GUARD zero samples.  *len is set to the total number of complex
+// samples written (tone + guard).
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 void cw_tone_get_tx_samples(float complex *buf, int *len)
 {
     int i;
+    // Tone at Fs/4: exp(j*2*pi*0.25*n) = {1, j, -1, -j, 1, j, ...}
+    // Use exact values to avoid sinf/cosf rounding.
+    static const float complex tone_pattern[4] = {
+         1.0f + 0.0f * _Complex_I,
+         0.0f + 1.0f * _Complex_I,
+        -1.0f + 0.0f * _Complex_I,
+         0.0f - 1.0f * _Complex_I
+    };
     for (i = 0; i < CW_TONE_LEN; i++)
-        buf[i] = 1.0f + 0.0f * _Complex_I;
-    *len = CW_TONE_LEN;
-    //fprintf(stderr, "\n[cw_tone] get_tx_samples: len=%d", *len);
+        buf[i] = tone_pattern[i % 4];
+    // Guard interval: zeros between CW tone and OFDM preamble
+    for (i = 0; i < CW_TONE_GUARD; i++)
+        buf[CW_TONE_LEN + i] = 0.0f + 0.0f * _Complex_I;
+    *len = CW_TONE_LEN + CW_TONE_GUARD;
 }

--- a/cw_tone.h
+++ b/cw_tone.h
@@ -1,6 +1,6 @@
 /* This file was automatically generated.  Do not edit! */
 
-#define CW_TONE_TX_MAX_SAMPLES  128
+#define CW_TONE_TX_MAX_SAMPLES  (128 + 16)   /* tone + guard */
 
 void cw_tone_init(void);
 void cw_tone_reset(void);

--- a/tests/test_cw_tone.c
+++ b/tests/test_cw_tone.c
@@ -52,17 +52,25 @@ static void test_cw_tone_init(void)
 
 static void test_cw_tone_tx_samples(void)
 {
-    TEST_BEGIN("cw_tone: get_tx_samples fills 128 DC samples");
+    TEST_BEGIN("cw_tone: get_tx_samples fills Fs/4 tone + guard");
     float complex buf[256];
     int len = 0;
-    memset(buf, 0, sizeof(buf));
+    memset(buf, 0xAA, sizeof(buf));  // fill with garbage to detect unwritten slots
 
     cw_tone_get_tx_samples(buf, &len);
 
-    TEST_ASSERT(len == 128);
-    // All samples should be 1.0 + 0.0j
-    for (int i = 0; i < len; i++) {
-        TEST_ASSERT(crealf(buf[i]) == 1.0f);
+    TEST_ASSERT(len == 128 + 16);  // tone + guard
+
+    // First 128 samples: Fs/4 tone {1, j, -1, -j, ...}
+    static const float expected_re[4] = { 1.0f,  0.0f, -1.0f,  0.0f};
+    static const float expected_im[4] = { 0.0f,  1.0f,  0.0f, -1.0f};
+    for (int i = 0; i < 128; i++) {
+        TEST_ASSERT(crealf(buf[i]) == expected_re[i % 4]);
+        TEST_ASSERT(cimagf(buf[i]) == expected_im[i % 4]);
+    }
+    // Last 16 samples: guard interval (zeros)
+    for (int i = 128; i < len; i++) {
+        TEST_ASSERT(crealf(buf[i]) == 0.0f);
         TEST_ASSERT(cimagf(buf[i]) == 0.0f);
     }
     TEST_PASS();
@@ -327,6 +335,43 @@ static void test_cw_tone_detect_near_coarse_limit(void)
     TEST_PASS();
 }
 
+static void test_cw_tone_roundtrip_tx_rx(void)
+{
+    TEST_BEGIN("cw_tone: roundtrip TX->RX recovers known CFO through Fs/4 tone");
+    float complex tx_buf[256];
+    int tx_len = 0;
+    cw_tone_get_tx_samples(tx_buf, &tx_len);
+
+    // Apply a known CFO to the TX tone samples and feed to detector.
+    // The Fs/4 tone is invisible to the autocorrelation estimator, so the
+    // detector should report the applied CFO directly.
+    float target_cfo = 0.003f;  // cycles/sample
+    cw_tone_init();
+    int detected = 0;
+
+    for (int n = 0; n < 256; n++) {
+        // Use tone portion only (skip guard zeros — they carry no tone info)
+        int idx = n % 128;
+        float phase = 2.0f * (float)M_PI * target_cfo * (float)n;
+        float complex cfo_phasor = cosf(phase) + sinf(phase) * _Complex_I;
+        float complex sample = tx_buf[idx] * cfo_phasor;
+        if (cw_tone_execute(sample)) {
+            detected = 1;
+            break;
+        }
+    }
+
+    TEST_ASSERT_MSG(detected, "roundtrip tone should be detected");
+    float est_cfo = cw_tone_get_freq_offset();
+    float error = fabsf(est_cfo - target_cfo);
+    char msg[128];
+    snprintf(msg, sizeof(msg),
+             "roundtrip CFO est=%.6f target=%.6f err=%.6f",
+             est_cfo, target_cfo, error);
+    TEST_ASSERT_MSG(error < 0.001f, msg);
+    TEST_PASS();
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // main
 ///////////////////////////////////////////////////////////////////////////////
@@ -349,6 +394,7 @@ int main(void)
     RUN_TEST(test_cw_tone_detect_large_negative_cfo);
     RUN_TEST(test_cw_tone_detect_moderate_cfo);
     RUN_TEST(test_cw_tone_detect_near_coarse_limit);
+    RUN_TEST(test_cw_tone_roundtrip_tx_rx);
 
     TEST_SUMMARY();
     return TEST_EXIT_CODE();

--- a/tests/test_cw_tone_channel.c
+++ b/tests/test_cw_tone_channel.c
@@ -1011,6 +1011,90 @@ static void test_noise_sandwich_awgn(void)
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// DC leakage immunity — validate Fs/4 tone rejects carrier leakage
+///////////////////////////////////////////////////////////////////////////////
+
+static void test_channel_dc_leakage_immunity(void)
+{
+    TEST_BEGIN("channel: Fs/4 tone immune to DC leakage");
+    cw_tone_init();
+    srand(15000);
+
+    // Generate TX samples (Fs/4 tone + guard)
+    float complex tx_buf[CW_TONE_LEN + CW_TONE_GUARD];
+    int tx_len = 0;
+    cw_tone_get_tx_samples(tx_buf, &tx_len);
+
+    // Simulate: TX tone + CFO + severe DC leakage from AD9361 LO
+    float target_cfo = 0.003f;
+    float dc_leakage = 0.3f;  // 30% of signal amplitude — severe case
+    int detected = 0;
+    float est_cfo = 0.0f;
+
+    for (int n = 0; n < 512; n++) {
+        int idx = n % CW_TONE_LEN;  // use tone portion only
+        float phase = 2.0f * (float)M_PI * target_cfo * (float)n;
+        float complex cfo_phasor = cosf(phase) + sinf(phase) * _Complex_I;
+        float complex sample = tx_buf[idx] * cfo_phasor;
+
+        // Add DC leakage (constant complex offset, typical of LO leakage)
+        sample += dc_leakage + 0.0f * _Complex_I;
+
+        if (!detected && cw_tone_execute(sample)) {
+            detected = 1;
+            est_cfo = cw_tone_get_freq_offset();
+        }
+    }
+
+    TEST_ASSERT_MSG(detected, "Fs/4 tone should be detected despite DC leakage");
+    char msg[128];
+    snprintf(msg, sizeof(msg), "est=%.6f target=%.6f err=%.6f",
+             est_cfo, target_cfo, fabsf(est_cfo - target_cfo));
+    TEST_ASSERT_MSG(fabsf(est_cfo - target_cfo) < 0.002f, msg);
+    TEST_PASS();
+}
+
+static void test_channel_roundtrip_with_impairments(void)
+{
+    TEST_BEGIN("channel: roundtrip TX->RX with CFO + noise + DC leakage");
+    cw_tone_init();
+    srand(15001);
+
+    float complex tx_buf[CW_TONE_LEN + CW_TONE_GUARD];
+    int tx_len = 0;
+    cw_tone_get_tx_samples(tx_buf, &tx_len);
+
+    float target_cfo = -0.004f;
+    float phase_offset = 1.2f;
+    float dc_leakage_re = 0.2f;
+    float dc_leakage_im = -0.1f;
+    float noise_sigma = 0.1f;   // ~20 dB SNR
+    int detected = 0;
+    float est_cfo = 0.0f;
+
+    for (int n = 0; n < 512; n++) {
+        int idx = n % CW_TONE_LEN;
+        float phase = 2.0f * (float)M_PI * target_cfo * (float)n + phase_offset;
+        float complex cfo_phasor = cosf(phase) + sinf(phase) * _Complex_I;
+        float complex sample = tx_buf[idx] * cfo_phasor;
+        sample += dc_leakage_re + dc_leakage_im * _Complex_I;
+        sample += awgn(noise_sigma);
+
+        if (!detected && cw_tone_execute(sample)) {
+            detected = 1;
+            est_cfo = cw_tone_get_freq_offset();
+        }
+    }
+
+    TEST_ASSERT_MSG(detected, "should detect through combined impairments + DC leakage");
+    char msg[128];
+    snprintf(msg, sizeof(msg), "est=%.6f target=%.6f err=%.6f",
+             est_cfo, target_cfo, fabsf(est_cfo - target_cfo));
+    TEST_ASSERT_MSG(fabsf(est_cfo - target_cfo) < 0.003f, msg);
+    TEST_PASS();
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // Frequency drift (time-varying CFO)
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -1116,6 +1200,10 @@ int main(void)
     // Noise sandwich (leading + lagging)
     RUN_TEST(test_noise_sandwich);
     RUN_TEST(test_noise_sandwich_awgn);
+
+    // DC leakage immunity (Fs/4 tone)
+    RUN_TEST(test_channel_dc_leakage_immunity);
+    RUN_TEST(test_channel_roundtrip_with_impairments);
 
     // Drift
     RUN_TEST(test_channel_frequency_drift);


### PR DESCRIPTION
The AD9361 direct-conversion receiver has carrier leakage (LO leakage)
at DC which corrupts the CW tone used for CFO estimation. Move the tone
to Fs/4 (0.25 cycles/sample = 350 kHz at 1.4 MHz) where it is well
separated from the DC spur.

The tone frequency 0.25 cyc/samp is chosen so that both autocorrelation
lags produce integer multiples of full rotations (0.25*4=1, 0.25*64=16),
making the tone invisible to the two-stage CFO estimator — no RX
algorithm changes needed.

Also add a 16-sample zero guard interval between the CW tone and the
OFDM preamble to prevent tone energy from leaking into PLCP detection.

Over-the-air frame: [CW tone 128] [guard 16 zeros] [OFDM PLCP + data]

https://claude.ai/code/session_01AVeFA1jerHbyHs2YX74aUX